### PR TITLE
fix(pca): correct 11 wrong answer keys in practice questions

### DIFF
--- a/.claude/state/research/2026-08-09-pca-content-audit.md
+++ b/.claude/state/research/2026-08-09-pca-content-audit.md
@@ -1,0 +1,247 @@
+# PCA content audit - 2026-08-09
+
+Full fact-check of `gcp/pca/` against `cloud.google.com`, run by a panel of GCP experts.
+Scope: all 10 doc files, all 260 practice questions, and `gcp/pca/README.md`.
+
+This file is the errata backlog. Items are removed as they are fixed, not ticked off.
+
+Status legend: `[ ]` open, `[x]` fixed, `[?]` needs a decision before fixing.
+
+---
+
+## P0 - wrong answer keys (teaches the wrong answer)
+
+All fixed on branch `fix/pca-answer-key-errata` (2026-08-09). Kept here as the record of what changed.
+
+- [x] `questions/section-1-designing-planning.md:310` Q18 - WebSocket LB answer is backwards. Marked D (global external proxy NLB); correct is A. External Application LB supports WebSocket with no configuration. The cookie-affinity rationale at :322 is invented. https://cloud.google.com/load-balancing/docs/https#websocket_proxy_support
+- [x] `questions/section-1-designing-planning.md:395` Q23 - marked answer cites "Cloud Load Test", which is not a Google Cloud product. Replace with distributed load testing on GKE (Locust/k6), as `section-6-operations-excellence.md:641` already does correctly.
+- [x] `questions/section-1-designing-planning.md:847` Q49 - option E wrongly marked incorrect. The stem specifies Software Assurance, so License Mobility applies and BYOL on standard multi-tenant Compute Engine is valid. The claim at :860 that Microsoft licensing requires sole-tenant is false for this case. https://cloud.google.com/compute/docs/instances/windows/ms-licensing
+- [x] `questions/section-2-provisioning-infrastructure.md:45` Q3 - marked answer names "Global external Application Load Balancer (Classic)". Classic is legacy; drop the qualifier.
+- [x] `questions/section-2-provisioning-infrastructure.md:284` Q17 - no option meets the stated deadline. 200 TB at 1 Gbps is ~18.5 days and Transfer Appliance round trip also exceeds 2 weeks. Change the stem to a 30-day deadline.
+- [x] `questions/section-2-provisioning-infrastructure.md:370` Q22 - marked answer labels C3D "compute-optimized". C3/C3D are general-purpose; compute-optimized is H4D/H3/C2/C2D. Swap to C2D or relabel.
+- [x] `questions/section-2-provisioning-infrastructure.md:438` Q26 - distractor A is no longer wrong. Autopilot supports GKE Sandbox, Dataplane V2 network policy and Binary Authorization, so A also satisfies the PCI-DSS requirements. Two defensible answers.
+- [x] `questions/section-2-provisioning-infrastructure.md:506` Q30 - internally contradictory. Stem requires 96 vCPU / 360 GB / 4x T4; `a2-highgpu-4g` is 48 vCPU / 340 GB / 4x A100. Make option B an N1 custom machine type with 4x T4 as Spot VMs.
+- [x] `questions/section-2-provisioning-infrastructure.md:540` Q32 - unachievable. Stem demands 4 TB RAM and 224 vCPUs; M3 tops out at 128 vCPUs. Explanation at :550 also claims M3 offers 30 TB memory (wrong by ~7x). Rewrite the stem to 3 TB / 128 vCPU, or make option B M4.
+- [x] `questions/section-3-security-compliance.md:756` Q40 - answer block is corrupted. Lines 767-773 contain three different verdicts plus visible model reasoning ("Actually, let me clarify"). Also unanswerable as a two-pick because the stem describes both user classes. Split into two questions or restrict the stem to root access.
+- [x] `questions/section-5-managing-implementations.md:200` Q8 - the reason B is rejected is false. Storage Transfer Service does support on-premises and private file systems via agent-based transfers. https://cloud.google.com/storage-transfer/docs/overview
+
+## P1 - explanations that state false facts
+
+Marked answer survives; the reasoning does not.
+
+- [ ] `questions/section-1-designing-planning.md:182` Q10 - "no Spot VM option for Dataflow workers". Dataflow FlexRS uses preemptible VMs for most of the batch pool.
+- [x] `questions/section-1-designing-planning.md:390` Q22 and `:770` Q44 - both claim Firestore multi-region is eventually consistent. Firestore reads are strongly consistent by default, including multi-region.
+- [ ] `questions/section-1-designing-planning.md:719` Q41 - "Vertex AI Endpoints do not support scaling to zero with GPUs". Scale-to-zero via `min_replica_count=0` now supports GPU deployments.
+- [ ] `questions/section-2-provisioning-infrastructure.md:177` Q10 - "Standard Tier does not support Cloud Armor". Regional Cloud Armor policies attach to the regional external ALB, which runs on Standard Tier.
+- [ ] `questions/section-2-provisioning-infrastructure.md:192` Q11 - justifies Nearline for quarterly access. Google maps monthly to Nearline, quarterly to Coldline. Marked answer stays; reasoning contradicts the class definitions.
+- [x] `questions/section-2-provisioning-infrastructure.md:535` Q31 - "Autopilot restricts DaemonSets to system-level add-ons". User DaemonSets are supported.
+- [ ] `questions/section-4-optimizing-processes.md:433` Q16 - built on `terraform refresh`, deprecated since 0.15.4 in favour of `apply -refresh-only`.
+- [ ] `questions/section-6-operations-excellence.md:87` Q3 - streaming inserts priced at "$0.01/200KB". Actual legacy rate is $0.010 per 200 MB. 1000x error.
+- [ ] `questions/section-6-operations-excellence.md:354` Q13 - "escalation policy in Cloud Monitoring". No native escalation or acknowledgement tier exists; escalation comes from a PagerDuty-class notification channel.
+- [ ] `questions/section-6-operations-excellence.md:493` - typo "addatively" in the composite SLA explanation.
+- [ ] `questions/case-study-questions.md:384` Q14 - "Autopilot doesn't support Spot VMs". Autopilot supports Spot Pods.
+- [ ] `questions/section-4-optimizing-processes.md:174` Q7 and `section-6-operations-excellence.md:258` Q10 - conflate Skaffold verify with Cloud Deploy deploy analysis. Right answer, wrong mechanism named. https://cloud.google.com/deploy/docs/analysis
+
+## P1 - non-existent commands in the docs
+
+A learner who types these gets "unrecognized". Highest-confusion class of error.
+
+- [ ] `docs/02:1724`, `02:1731` - `gcloud ai pipelines run create` / `schedules create`. No `pipelines` group under `gcloud ai`. Pipelines are SDK/REST only.
+- [ ] `docs/02:1933` - `gcloud ai batch-prediction-jobs create`. No such group.
+- [ ] `docs/02:1793`, `02:1799` - `gcloud ai feature-online-stores` / `feature-views` exist only under `gcloud beta ai`.
+- [ ] `docs/03:769-777` - `gcloud dlp inspect-content` / `deidentify-content`. Actual surface is `gcloud alpha dlp text inspect` / `redact`.
+- [ ] `docs/03:611-614` and `04:385-387` - `--enable-vulnerability-scanning`. Real flag is `--allow-vulnerability-scanning`.
+- [ ] `docs/04:77-84` and `06:1350-1363` and `07:145` - `gcloud monitoring slos create/list/describe`. No `slos` group. SLOs come from the Monitoring API v3, Terraform `google_monitoring_slo`, or the console. Significant because 6.5 is the SLO objective.
+- [ ] `docs/04:713-717` - `gcloud logging metrics create --bucket-options=...`. No such flag; distribution metrics need `--config-from-file`.
+- [ ] `docs/04:889-898` - `gcloud privatecatalog catalogs create` / `products create`. Not real; the surface is search-only. Product also renamed to Service Catalog in 2022.
+- [ ] `docs/04:1352-1357` - `gcloud monitoring policies create --condition-display-name/--condition-filter/--condition-threshold-value`. Invented flags; takes `--policy` / `--policy-from-file`.
+- [ ] `docs/06:76`, `06:80-85` - `gcloud monitoring metrics-descriptors list/create`. No such group on any track. GA groups are dashboards, policies, snoozes, uptime.
+- [ ] `docs/06:234`, `06:237-240`, `07:139-142` - `gcloud monitoring channels`. Beta only.
+- [ ] `docs/06:634` - `gcloud beta error-events list`. Correct group is `gcloud beta error-reporting events list`.
+- [ ] `docs/07:1293` - `gcloud beta carbon-footprint get`. No such group; use the BigQuery export.
+- [ ] `docs/10:184-186` - `gcloud ai pipelines runs create`. Fabricated.
+- [ ] `docs/05:2040` - `gcloud services quota update` is alpha-only.
+- [ ] `docs/07:831` - org policy `constraints/compute.requireLabels` does not exist. Label governance uses tags or apply-time policy-as-code.
+- [ ] `docs/07:361` - `enable-enforce` used on `compute.vmExternalIpAccess`, which is a list constraint needing `set-policy`. The three neighbouring boolean constraints are correct, which makes this harder to spot.
+
+## P1 - numbers that are wrong
+
+- [ ] `docs/07:1026` - Hyperdisk "up to 2.4 TB/s". Off by 1000x. Hyperdisk Balanced maxes at 2,400 MiB/s per volume; Extreme at 5,000 MiB/s; only Hyperdisk ML reaches ~2 TiB/s.
+- [ ] `docs/06:68` - metric retention "5 years". Actual 24 months (6 weeks native, then 10-minute).
+- [ ] `docs/06:72` - log-based metrics "24 months". Actual 6 weeks.
+- [ ] `docs/06:1226` - Enhanced support minimum "$500/month" (actual $100); Premium "contact sales" (published minimum $15,000/month).
+- [ ] `docs/06:2034`, `06:2105` - GKE maintenance exclusion `no_upgrades` "cannot exceed 180 days". Actual 90 days, plus a 48-hours-per-92-day-window rule.
+- [ ] `docs/05:621`, `05:647`, `05:727` - Cloud Shell "resets after 120 min inactivity" / "20 min idle". Actual: session ends after 40 minutes idle, 12-hour session cap, `$HOME` deleted after 120 days.
+- [ ] `docs/09:118` - Spanner "~$650/mo min". Wrong by 10x. Minimum is 100 processing units; 1000 PU = 1 node.
+- [ ] `docs/01:576` - Spanner "1 node ~ 10,000 reads/sec or 2,000 writes/sec". Current: 22,500 peak reads/sec, 3,500 peak writes/sec (22,500 with throughput-optimized writes).
+- [ ] `docs/02:873` - Bigtable "10K rows/sec reads and writes". Current SSD node: up to 17,000 reads/sec, 14,000 writes/sec.
+- [ ] `docs/07:624` - `nam14` replica list wrong. Actual: read-write in us-east4 (default leader) and northamerica-northeast1, witness in us-east1.
+- [ ] `docs/07:749`, `07:760` - CUD "20-57%" / "~57% memory-optimized". Actual up to 55% for most series, up to 70% memory-optimized. Flexible CUDs (17-63%) missing entirely.
+- [ ] `docs/04:1457-1462` - SUD tier table (~8.3% / ~16.7% / 30%). Published tiers are 0 / 10 / 20 / 30% across quartiles.
+- [ ] `docs/04:1453` - "SUDs do not apply to sole-tenant nodes". They do, including the sole-tenancy premium.
+- [ ] `docs/01:126-127` - claims C2 is SUD-ineligible. C2 is eligible (20% max), as are M1 and M2 (30%). The flat "up to 30%" is wrong for N2/N2D/C2.
+- [ ] `docs/02:997` - Firestore PITR "enabled by default, 1-hour granularity". Both wrong: disabled by default, 1-minute granularity. Contradicts `01:674` which is correct.
+- [ ] `docs/02:900` - BigQuery Standard edition shown with 1yr/3yr commitments. Standard has no capacity commitments.
+- [ ] `docs/02:1577` - Cloud Run "max timeout 60 min (default)". Default is 5 minutes; 60 is the max.
+- [ ] `docs/02:1628` - Cloud Run functions "up to 16 GiB / 4 vCPU". Actual 32 GiB / 8 vCPU.
+- [ ] `docs/02:1349` - Serverless VPC Access "up to 1 Gbps". That is the e2-micro ceiling; e2-standard-4 reaches 3,200-16,000 Mbps.
+- [ ] `docs/02:272-277`, `02:323` - firewall precedence order wrong for the default `AFTER_CLASSIC_FIREWALL` enforcement.
+- [ ] `docs/02:740`, `02:751`, `01:237` - three different Transfer Appliance capacities, all retired. Current models are TA40 (40 TB) and TA300 (300 TB).
+- [ ] `docs/02:1089` - M2 listed as "12-416" vCPUs. M2 starts at 208. M1 and M4 missing entirely.
+- [ ] `docs/03:252` - SDP "150+ built-in detectors". Actual 200+.
+- [ ] `docs/09:311` - Interconnect 99.9% SLA needs two connections in different edge availability domains, not just one metro.
+- [ ] `docs/09:305`, `09:309`, `09:367` - Dedicated Interconnect "10-200 Gbps". Now 10, 100 and 400 Gbps link types.
+- [ ] `docs/09:322`, `09:329`, `09:369` and `02:22` - HA VPN "3 Gbps per tunnel". Documented limit is 250,000 packets/sec, which is 1-3 Gbps depending on packet size.
+- [ ] `docs/07:858-862` - inter-region egress "$0.01/GB". Within North America it is $0.02/GB.
+- [ ] `docs/07:711` and `02:596` conflict on storage class SLAs. `02:596` is correct (99.9% multi/dual-region, 99.0% regional for the cold classes). `07:711` flattens all three to 99.0% and is wrong.
+- [ ] `docs/01:727` - Dedicated Interconnect "99.9% (1 link)". A single link carries no SLA.
+- [ ] `docs/06:1371` vs `06:668`/`06:1388-1391` - two different downtime bases (43.8 vs 43.2 min). Pick the 30-day basis and make it consistent.
+
+## P1 - facts that are wrong but not numeric
+
+- [ ] `docs/04:305` - "the `images` field does NOT push to a registry". It does. Stated as an exam tip, which makes it worse.
+- [ ] `docs/04:301` - Cloud Build default SA. New projects default to the Compute Engine default SA, not `{PROJECT_NUMBER}@cloudbuild.gserviceaccount.com`.
+- [ ] `docs/04:788`, `04:795`, `04:869` and `05:270` and `07:660` - "Cloud Load Testing" as a Google product, with a doc link that does not resolve. No such product has ever existed.
+- [ ] `docs/04:539-543`, `04:667` - "Cloud Deploy rollback means creating a new release". Native rollback exists (`gcloud deploy targets rollback`) plus automated rollback rules.
+- [ ] `docs/04:668` - "Cloud Deploy canary requires a service mesh". It supports plain Kubernetes service networking.
+- [ ] `docs/04:693` - Cloud Debugger "replaced by Snapshot Debugger". Both are gone; delete the row.
+- [ ] `docs/04:1015` - "Memorystore Redis cross-region replication, Standard tier". Standard tier is cross-zone within one region. Cross-region is a Redis Cluster / Valkey feature.
+- [ ] `docs/04:1414` - resource-based CUDs cover Dataflow. They do not.
+- [ ] `docs/04:1291` - "AlloyDB single-region only". AlloyDB supports cross-region replication.
+- [ ] `docs/03:226-227` - "Key Access Justifications only available with EKM". KAJ works on software and HSM keys too.
+- [ ] `docs/03:583`, `03:641` - "Binary Authorization is for GKE". Also Cloud Run, Cloud Service Mesh, Google Distributed Cloud. Contradicts `04:397`.
+- [ ] `docs/03:620-624` - SLSA "Level 1-4". v1.0 Build track has L1-L3 only.
+- [ ] `docs/03:812` - "Artifact Hub" for compliance reports. Not a Google product. Correct: Compliance Reports Manager, and Audit Manager for evidence generation.
+- [ ] `docs/03:853` - Access Transparency "Premium or Enterprise support". Actual: Standard, Enhanced or Premium. Enterprise is not a Care tier.
+- [ ] `docs/06:325` - "Policy Denied logs can exempt specific users". No principal-exemption mechanism; only a Log Router exclusion filter.
+- [ ] `docs/06:1712` - Web Security Scanner "App Engine and Cloud Run". Actual: App Engine, GKE, Compute Engine. Cloud Run not supported. Contradicts `06:1699` two lines earlier.
+- [ ] `docs/06:1993` - VM Manager metadata key `enable-os-config`. Correct key is `enable-osconfig`.
+- [ ] `docs/05:502` - Datastream destinations include "Cloud SQL (PostgreSQL)". Actual: BigQuery, Cloud Storage, Apache Iceberg.
+- [ ] `docs/05:165` - "Apigee Integrated" tier does not exist. Tiers are Standard, Enterprise, Enterprise Plus, plus pay-as-you-go.
+- [ ] `docs/05:372-397` - the entire Migrate to Containers section is dead. `migctl` and the processing-cluster flow were removed in May 2024.
+- [ ] `docs/05:2271` - decision tree offers "service account with key (or WIF)" for CI/CD. Keys should be a distractor, not a branch. Contradicts `05:2055`.
+- [ ] `docs/09:15`, `09:98` - "Autopilot has no DaemonSets" and "need DaemonSets or GPUs, use Standard". Both wrong, stated twice. Autopilot supports both.
+- [ ] `docs/09:148`, `09:200` - "Firestore cannot change mode after creation". An empty database can switch, and both modes can coexist in one project.
+- [ ] `docs/09:141` - "Firestore under 10 TB" as a branch condition. No such documented limit; invented threshold.
+- [ ] `docs/09:157` - "Bigtable has no SQL". GoogleSQL for Bigtable is GA.
+- [ ] `docs/09:113` - "Spanner 99.999% SLA" as the entry condition. Five nines is multi-region only; regional is 99.99%.
+- [ ] `docs/09:120`, `09:196` - AlloyDB "4x Cloud SQL performance". The claim is 4x standard PostgreSQL.
+- [ ] `docs/09:556` - conflates CSEK and EKM. The file's own tip at `09:602` gets it right.
+- [ ] `docs/09:540-542` - recommends network tags over service accounts for firewall targeting. Google recommends the opposite; secure tags now close the gap.
+- [ ] `docs/09:808` - "Cloud SQL cross-region DR requires manual promotion". Enterprise Plus supports advanced DR with replica failover and zero-data-loss switchover.
+- [ ] `docs/09:765` - turbo replication placed in "hot DR, RPO seconds to minutes". Its guarantee is 15 minutes, matching `09:281`/`09:809`.
+- [ ] `docs/10:765` - "network policy requires Calico, enabled by default on Standard". Not enabled by default; Dataplane V2 is the recommended plugin and the Autopilot default.
+- [ ] `docs/10:136-139` - the global external ALB snippet builds a classic ALB. Needs `--load-balancing-scheme=EXTERNAL_MANAGED` on backend service and forwarding rule. Contradicts `09:410-411`.
+- [ ] `docs/10:113-116` - HA VPN example uses `--peer-gcp-gateway` (VPC-to-VPC) while the text describes the on-prem case, which needs `--peer-external-gateway`.
+- [ ] `docs/10:57-61` - WIF OIDC provider created with no `--attribute-condition`. For the GitHub issuer this lets any repository mint tokens. Must be repository-scoped.
+- [ ] `docs/10:815` - `gsutil signurl` requires a downloaded SA key, contradicting `09:506` ("no service account keys, ever"). Use `gcloud storage sign-url --impersonate-service-account`.
+- [ ] `docs/01:1082` - "Migration Center (formerly Migrate for Compute Engine)". False lineage; M4CE became Migrate to VMs, Migration Center is a separate product. File contradicts itself at `01:1093`.
+- [ ] `docs/01:795` - "Vertex AI Conversation replaces Dialogflow CX for new projects". Dialogflow CX is the underlying engine, rebranded Conversational Agents. Never replaced.
+- [ ] `docs/01:949`, `01:676` - dual-region "sub-second failover" / "near-zero RPO". No such guarantee. Default is most objects within 15 minutes; turbo guarantees 15 min for 100%.
+- [ ] `docs/01:463` - "Memorystore Redis Standard (single zone)". Standard places the replica in a different zone.
+- [ ] `docs/01:1157` - "Azure Hybrid Benefit equivalent". Google has no such thing; Microsoft Listed Provider terms generally require sole-tenant nodes.
+- [ ] `docs/02:1557` - "Autopilot billing is per-pod". Workloads selecting hardware via ComputeClasses are billed node-based.
+- [ ] `docs/02:1480`, `02:1493` - "Autopilot DaemonSets limited to an allowlist". The allowlist applies to privileged workloads, not DaemonSets.
+- [ ] `docs/02:343` - "25 peering limit per VPC". Quota is increasable on request.
+- [ ] `docs/02:25-26` - "Classic VPN deprecated for new deployments". Not marked deprecated; de-emphasized, still carries a 99.9% SLA.
+
+## P2 - stale product naming (systematic sweep, not one-offs)
+
+The Vertex AI rebrand is the big one and is a rewrite, not a find-and-replace.
+
+- [?] **Vertex AI to Gemini Enterprise Agent Platform.** Rebranded at Cloud Next 2026; Vertex AI left the Console 2026-05-21. "Vertex AI Agent Builder" appears as a *correct answer* in `section-1-designing-planning.md:659` and `:1094`, `section-2-provisioning-infrastructure.md:661`, `case-study-questions.md:207`. Model tables reference SKUs that now 404 (`docs/02:2098-2100`, `02:2190`, `01:787`). Affects docs 01, 02, 09.
+  **Decision needed:** the v6.1 exam guide (Oct 2025) still uses Vertex AI naming. Recommendation is to keep exam-guide names primary and add a "now marketed as" note, rather than rewriting to names the exam does not use.
+- [ ] **Anthos to GKE Enterprise**, **Anthos Service Mesh + Traffic Director to Cloud Service Mesh**: `docs/01:279`, `01:641`, `01:742`, `01:1043`, `02:425`, `02:1505`, `04:429`, `04:668`, `04:749`, `04:790`, `04:820`, `04:972`, `06:788`, `06:1586`, `06:1660`, `06:1674`, `07:102`, `07:469`, `07:1005`, `07:1388`, `05:115`.
+- [ ] **Container Registry shut down** (writes 2025-03-18, reads 2025-06-03) but `gcr.io` still used in examples: `docs/02:1363`, `02:1370`, `05:297`, `05:301`, `05:305`, `05:1671`, `06:867`, `06:892`, `06:976`, `06:1000`, `07:178`. Also listed as a VPC-SC protectable service at `03:369`.
+- [ ] **Cloud Functions to Cloud Run functions**: `docs/01:1018`, `05:169`, `05:216`, `05:238`, `06:622`, `06:641`, `07:562`, `07:977`, `07:803`, `07:1109`, `07:1231`, `questions/section-5-managing-implementations.md:229`, `:531`.
+- [ ] **Dataproc to Managed Service for Apache Spark**: `docs/09:62-66`, `09:93`, `09:100`, `09:891`, `09:1002`.
+- [ ] **Migrate for Compute Engine to Migrate to Virtual Machines**: `docs/09:835`, `09:889`, `09:903`, `09:1033`, `05:399`, `05:555`. M4CE v4.11 end of support 2024-04-30.
+- [ ] **BeyondCorp Enterprise to Chrome Enterprise Premium**: `questions/section-3-security-compliance.md:749`.
+- [ ] **Cloud Operations Suite to Google Cloud Observability**: `docs/01:414`, `07:222`, `07:1476`.
+- [ ] **Cloud Source Repositories** closed to new customers 2024-06-17, presented as live: `docs/01:180`, `04:28`, `04:580`. Successor is Secure Source Manager.
+- [ ] **Deployment Manager** past end of support 2026-03-31, new users blocked from 2026-06-30: `docs/05:1809-1841`, `09:937-941`, `09:967`, `09:974`, `10:592`, `10:600`, `04:881`.
+- [ ] **Memorystore for Memcached deprecated** (no new instances after 2027-02-01, shutdown 2029-01-31): `docs/09:174`, `09:191`. Memorystore for Valkey missing entirely from the in-memory branch.
+- [ ] **PaLM 2 and Codey retired** April 2025: `docs/02:2156`, `09:634`.
+- [ ] **Model Armor is under Security Command Center**, not Vertex AI: `questions/section-3-security-compliance.md:654`, `docs/03:650-654` (also wrong doc URL).
+- [ ] **Cloud Armor Managed Protection Plus to Cloud Armor Enterprise**: `docs/02:214`.
+- [ ] **Private Catalog to Service Catalog** (renamed March 2022): `docs/04:879`, `04:936-937`.
+- [ ] **Terraform Cloud to HCP Terraform**: `docs/05:1262`.
+- [ ] **gsutil to gcloud storage.** gsutil leaves the CLI bundle March 2027. `docs/10:806-825` gives gsutil its own section while `gcloud storage` is absent. Invert the emphasis but keep gsutil, since the exam guide still names it.
+- [ ] Dated version pins that will rot: TPU v3 (`questions/section-1-designing-planning.md:472`), GKE 1.28/1.29 (`section-6:587`), pd-ssd with no Hyperdisk (`section-2:492`), provider `~> 5.0` (`docs/10:285-294`, `05:1122-1129`) against a current 7.x, `POSTGRES_15` (`10:505`), CFT module pins (`10:412`, `10:427`).
+- [ ] `docs/06:1589` - Istio `networking.istio.io/v1alpha3`. Current is `v1` since Istio 1.22.
+- [ ] `docs/02:5` claims "Last updated: February 2026", now stale and predating the rebrand. `docs/01` has no last-updated marker.
+
+## P2 - README and exam-metadata problems
+
+- [?] `README.md:16-25` - **the section weight table is unsourced.** Google does not publish per-section weights for PCA. These look reverse-engineered from objective counts. A learner allocating study time on invented weights is the worst failure mode here. Either drop them or label them clearly as an estimate.
+- [ ] `README.md:11` - omits the officially published figure: case study questions are **20-30% of the exam**. This is the most actionable planning fact available and it is missing.
+- [ ] `README.md:3-14` - does not pin the exam guide version. Current is **v6.1, effective 2025-10-30**, which added the Vertex AI sections 2.4/2.5, made WAF and Terraform/IaC explicit, added "Securing AI", and swapped out Helicopter Racing League / Mountkirk Games / TerramEarth for the current case studies. Pin it so drift is detectable.
+- [ ] `README.md:3-14` - the **Renewal exam** is absent: 1 hour, 25 questions, $100, 1 case study aligned to generative AI, and case-study questions are 90-100% of that exam.
+- [ ] `README.md:65` - "~20% multi-select" is unsourced. The official page says "multiple choice and multiple select" with no ratio.
+- [x] Case study names verified correct against the official page: EHR Healthcare, Cymbal Retail, Altostrat Media, KnightMotives Automotive. Exam facts verified: 2 hours, 50-60 questions, $200, 2-year validity, 4 cases with 2 on the exam.
+
+## P2 - question bank structural issues
+
+- [ ] **Multi-select is 13.1% (34 of 260), against a target of ~20%.** Worst gap is section 2 (3 of 45). Adding ~18 conversions, mostly in sections 1 and 2, reaches 20%.
+- [ ] `questions/section-4-optimizing-processes.md:257` Q10 - the only 6-option item in the bank (A-F for a "choose THREE").
+- [ ] **All 20 case study questions are answerable without reading the case study.** Every needed constraint is restated in the stem and the numbers are invented rather than drawn from the case documents: `case-study-questions.md:69`, `:121`, `:151`, `:289`, `:423`. Q5 and Q11 duplicate `section-4:288` and `section-2:284`. Q9 restates `section-5:11`. Fix by quoting verbatim requirements from the case documents and making two options plausible until that requirement is applied.
+- [ ] **~15-20% of questions are answerable by elimination alone.** Worst: `section-2:16`, `:169`, `:511`; `section-4:818`, `:928`, `:289`; `section-5:289`, `:400`; `section-6:346`, `:619`; `case-study:323`. The stakeholder-management questions in section 4 (Q25, Q26, Q30, Q34) are near-uniformly one-plausible-of-four.
+- [ ] **Recall vs judgment.** Sections 2 (~35-40%), 3 (~40%) and 5 (~35%) test service-fact recall rather than architectural trade-off. Roughly 55 questions across those three files would fit an ACE bank unchanged. Sections 1 (~10%), 4 (~15%) and case studies (~10%) are well calibrated.
+- [ ] Ambiguous or under-determined: `section-1:502` Q29, `section-1:344` Q20, `section-3:163` Q9, `section-2:455` Q27.
+
+## P3 - coverage gaps against the v6.1 exam guide
+
+- [ ] **Google Cloud VMware Engine** - named verbatim in objective 2.3, zero mentions anywhere. Belongs in `docs/02` under 2.3.
+- [ ] **Infrastructure Manager** - Google's managed Terraform and the named Deployment Manager replacement. Absent from `docs/05` and `docs/09` section 10. Biggest single gap given v6.1 made IaC explicit.
+- [ ] **Confidential Computing** - Confidential VMs, Confidential GKE Nodes, Confidential Space. Absent from `docs/03`.
+- [ ] **Workforce Identity Federation** - absent; only Workload Identity Federation is covered (`docs/03:529-560`). The workforce/workload distinction is a classic trap.
+- [ ] **Privileged Access Manager** - the canonical answer for just-in-time elevation and break-glass. Missing from separation of duties (`docs/03:269-303`).
+- [ ] **Cloud NGFW Enterprise** - objective 2.1 names intrusion protection; `docs/02:247-266` covers only Cloud IDS, which is detection-only.
+- [ ] **Network Connectivity Center** - two passing rows (`docs/02:188`, `02:344`), absent from the `docs/09` connectivity tree. Objective 2.1 covers exactly this.
+- [ ] **Metrics scopes** - multi-project observability, arguably the architect-level Cloud Monitoring topic. Absent from `docs/06`.
+- [ ] **SLO composition across dependent services** - the multiplicative rule is a classic PCA calculation, absent.
+- [ ] **DORA metrics** - absent from all files despite Google owning the research and citing it throughout WAF.
+- [ ] **Cloud Customer Care tiers** - `docs/04:1327-1377` "customer success" is effectively a second SLO section. Exam items framed as customer success often resolve to picking a support tier, and there is no basis for that here.
+- [ ] **Dynamic Workload Scheduler** - objective 2.4's "optimizing for different consumption models" is exactly this. Absent.
+- [ ] **Gemini Enterprise** (objective 2.5: AI Agents and NotebookLM) - NotebookLM gets one row; AI Agents absent.
+- [ ] Missing decision trees in `docs/09`, ranked by expected yield: resource hierarchy / landing zone, network topology selection, data pipeline and ingestion, multi-tenancy isolation, identity and federation, CI/CD topology, AI/ML serving, caching strategy, observability and logging architecture, cost optimization, compliance and data residency, encryption key strategy.
+- [ ] Thin relative to weight: securing AI (`docs/03:648-681`, 33 lines for a named objective), envisioning future improvements (`docs/01:1177-1237`, all of 1.5), success measurements (`docs/01:331-354`), Cloud Code (`docs/05:661-682`).
+- [ ] `docs/06:13-22` and `07:53-65` - the operational excellence "key principles" are hand-written SRE principles, not Google's published pillar principles. Objective 6.1 reads verbatim "the principles and recommendations of the operational excellence pillar", so a question quoting Google's wording would not be recognisable.
+
+## P3 - depth calibration (ACE-level filler to compress)
+
+PCA does not test flag recall. These blocks should compress to the decision they encode:
+
+- [ ] `docs/10:620-761` - ~140 lines of kubectl RBAC / NetworkPolicy / ResourceQuota YAML and rollout commands. Compress to a table of "isolation need to K8s primitive".
+- [ ] `docs/10:154-207` - KMS encrypt/decrypt, Vertex AI and Cloud Deploy command dumps.
+- [ ] `docs/02:36-81` - 45 lines of HA VPN and BGP peer commands. Keep the topology decision, drop the commands.
+- [ ] `docs/02:396-427` - six-step global external ALB creation sequence. The architect question is which LB and why, already answered at `02:372-394`.
+- [ ] `docs/02:1130-1183`, `02:538-570`, `02:1405-1421`, `02:2051-2066` - instance template/MIG, Cloud DNS, patch deployment, and pre-built AI API command blocks.
+- [ ] `docs/05:750-913` - 160 lines of gcloud/gsutil/bq/cbt/kubectl recall. `cbt` and the kubectl block have no PCA surface at all.
+- [ ] `docs/05:1964-2029`, `05:2088-2157` - hand-rolled pagination loop, manual backoff implementation, 30-line Go GCS function, full Pub/Sub and Secret Manager client code.
+- [ ] `docs/06:860-898`, `06:948-1017`, `06:1057-1075` - Cloud Deploy flags, 70 lines of blue/green YAML, kubectl rollout list.
+- [ ] `docs/04:115-297`, `04:331-377`, `04:506-550`, `04:1640-1668` - three near-identical cloudbuild.yaml variants, Artifact Registry CRUD, eleven gcloud deploy commands, label/tag CLI.
+- [ ] `docs/03:190-248`, `03:337-408` - KMS/Secret Manager and access-context-manager syntax.
+- [ ] Too deep for PCA: `docs/02:1941-1948` and `02:2169-2177` (quantization, distillation, pruning, RLHF, soft-prompt tuning - ML Engineer territory), `02:1977-1983` (parallelism strategies), `02:1834-1838` (TPU slice/ICI/DCN internals).
+
+Keep as the model for rewrites: `docs/07:1392-1441` (pillar trade-off matrix, the best-calibrated section in the repo), `07:1342-1357`, `05:205-226`, `05:530-553`, `05:1082-1091`, `06:1077-1084`, `06:2021-2029`, `02:340-346`, `02:1472-1495`, `01:277-297`, `01:659-679`.
+
+## P3 - structural defects
+
+- [ ] `docs/06:1166-1187` - the sample runbook is fenced but its internal markdown headings leak into the document outline, appearing as siblings of section 6.4.
+- [ ] `docs/04:1266-1288` - same problem with the ADR example's headings.
+- [ ] `docs/05:1809-1858` - IaC comparison table omits Infrastructure Manager.
+- [ ] `gcp/ace/docs/05-access-and-security.md:3` and `:1150` - `[Back to README](./README.md)` links to a file that does not exist; the README is one level up.
+- [ ] **ACE exam weights disagree across four files.** `gcp/ace/README.md:25-28` says Domain 1 ~23%, Domain 2 ~30%; the doc H1s say ~20% and ~17.5% on the older 5-domain scheme. Root `CLAUDE.md` agrees with the README. Question file headers restate it a fourth time.
+- [ ] **Question counts are maintained in five places**: root `CLAUDE.md`, `.claude/domain-reference.md:130-135` and `:36-46`, `.claude/study-modes.md:15-31`, both exam READMEs, and inside each question file. Single source of truth should be the `Total questions: N` line in each question file.
+- [ ] **The Cloud Storage class table appears in 9 doc files** and has already diverged (see `07:711` vs `02:596` above). Same shape for the Spot VM 60-91% figure (4 PCA files) and CMEK snippets (9 files).
+- [ ] Example timestamps now in the past: `docs/03:59`, `03:68`, `03:200`.
+- [ ] `docs/07:1207`, `07:1215-1221` - CFE scores from the 2021-2022 dataset. Either refresh or keep only the relative ordering.
+- [ ] `docs/04:1323` - doc link `cloud.google.com/architecture/architecture-decision-records` could not be confirmed to exist.
+- [ ] Note: `cloud.google.com/*` doc URLs now 301-redirect to `docs.cloud.google.com/*`. Existing links all resolve, so this is not a defect, but new links should use the new host.
+
+## Open items needing verification
+
+- [ ] `questions/section-3-security-compliance.md:202` Q11 assumes `cloudsql.instances.delete` is denyable via IAM deny policies. Deny policies cover a published subset; confirm Cloud SQL is on the supported list. https://cloud.google.com/iam/docs/deny-permissions-support
+- [ ] `questions/section-1-designing-planning.md:519` Q30 cites AlloyDB's 128 TB ceiling. Correct today, but exactly the kind of published limit that moves.
+- [ ] `questions/section-4-optimizing-processes.md:592` Q22 option B pairs "on-demand pricing" with "reservation assignment" in one clause, which reads as contradictory.

--- a/gcp/pca/questions/section-1-designing-planning.md
+++ b/gcp/pca/questions/section-1-designing-planning.md
@@ -317,9 +317,11 @@ D) GKE pods with a global external proxy Network Load Balancer with session affi
 <details>
 <summary>Answer</summary>
 
-**Correct: D)**
+**Correct: A)**
 
-WebSocket connections are long-lived TCP connections that need a proxy-based load balancer supporting WebSocket protocol upgrade and session affinity. The global external proxy Network Load Balancer (Envoy-based) supports TCP connections with session affinity and distributes traffic globally. GKE provides horizontal scaling of pods. Option A is wrong because the external Application Load Balancer works for WebSocket but is optimized for HTTP(S) traffic. While it can handle WebSocket via upgrade, cookie-based affinity requires the initial HTTP request to set a cookie, which adds complexity for WebSocket-first connections. The proxy Network Load Balancer is more appropriate for TCP-level affinity. Option B is wrong because the regional external TCP/UDP Network Load Balancer is a passthrough (non-proxy) load balancer -- it supports connection tracking but is regional only, limiting global distribution. Option C is wrong because Cloud Run has a maximum request timeout of 60 minutes (adjustable) but is designed for request-response patterns, not long-lived WebSocket connections at scale. Cloud Run also does not guarantee session affinity.
+The external Application Load Balancer has native WebSocket support: the protocol upgrade is handled automatically and no special configuration is required. Because a WebSocket connection begins as an HTTP request, cookie-based session affinity is set during that handshake and then holds for the life of the connection. GKE provides the horizontal pod scaling. Option B is wrong because the regional external TCP/UDP Network Load Balancer is a passthrough (non-proxy) load balancer and is regional only, so it cannot distribute globally. Option C is wrong because Cloud Run is designed for request-response patterns and does not guarantee session affinity across instances, which the 45-minute connections require. Option D is wrong because the global external proxy Network Load Balancer is not a documented WebSocket product; WebSocket support is a documented feature of the Application Load Balancer, and choosing a TCP proxy here gives up the HTTP-layer affinity the scenario asks for.
+
+**Exam tip:** WebSocket plus session affinity means Application Load Balancer, not a Network Load Balancer. The trap is reasoning "WebSocket is TCP, so pick the TCP load balancer" -- Google documents WebSocket as an Application Load Balancer capability that needs zero configuration. See [WebSocket proxy support](https://cloud.google.com/load-balancing/docs/https#websocket_proxy_support).
 </details>
 
 ---
@@ -387,14 +389,14 @@ D) Custom auth service in a single region with Cloud CDN caching auth tokens
 
 **Correct: B)**
 
-Cloud Spanner provides strongly consistent reads globally with multi-region deployment, ensuring session data is always up-to-date regardless of which region serves the request. Deploying the auth service in each region ensures < 50ms response times by processing requests locally. Option A is wrong because Firestore multi-region provides strong consistency within a region but eventual consistency for cross-region reads -- a session created in one region might not be immediately visible in another. Option C is wrong because Memorystore for Redis is regional only -- there is no cross-region replication, so a user who authenticates in North America and is then routed to Europe would not have their session. Option D is wrong because caching auth tokens at CDN is a security risk (tokens could be served from cache after revocation), and a single-region auth service means users in distant regions exceed the 50ms requirement.
+Cloud Spanner provides strongly consistent reads globally with multi-region deployment, ensuring session data is always up-to-date regardless of which region serves the request. Deploying the auth service in each region ensures < 50ms response times by processing requests locally. Option A is wrong, but not for the reason people usually give: Firestore reads are strongly consistent by default, including in multi-region. The real problem is write latency. Firestore's leader replicas live in the primary region, so a write originating far from that region pays a cross-region round trip, which eats the 50ms budget. Spanner lets you place the leader per configuration and is the better fit when writes are globally distributed. Option C is wrong because Memorystore for Redis is regional only -- there is no cross-region replication, so a user who authenticates in North America and is then routed to Europe would not have their session. Option D is wrong because caching auth tokens at CDN is a security risk (tokens could be served from cache after revocation), and a single-region auth service means users in distant regions exceed the 50ms requirement.
 </details>
 
 ---
 
 ### Q23. An e-commerce platform expects a 20x traffic increase during a flash sale event in 2 weeks. Their current GKE-based architecture handles normal traffic well. The architect needs to ensure the system can handle the surge without service degradation. Which combination of actions should they take? (Choose TWO)
 
-A) Perform load testing with Cloud Load Test to identify bottlenecks and determine required capacity
+A) Run distributed load testing on GKE with an open-source tool such as Locust or k6 to identify bottlenecks and determine required capacity
 B) Pre-warm the Cluster Autoscaler by setting minimum node count to expected peak capacity for the sale duration
 C) Switch all workloads to Spot VMs to reduce cost during the sale
 D) Configure Horizontal Pod Autoscaler with aggressive scaling policies (rapid scale-up, slow scale-down)
@@ -855,9 +857,11 @@ E) Run SQL Server on standard (multi-tenant) Compute Engine instances with BYOL
 <details>
 <summary>Answer</summary>
 
-**Correct: B) and C)**
+**Correct: C) and E)**
 
-Software Assurance includes License Mobility, but Microsoft SQL Server requires dedicated hardware for BYOL in the cloud. Sole-tenant nodes provide the physical isolation needed for BYOL compliance, allowing the company to use existing licenses without additional cost. Alternatively, migrating to AlloyDB (PostgreSQL-compatible) eliminates SQL Server licensing entirely, providing the most cost savings long-term if the application can be adapted. Option A is wrong because Google-provided SQL Server Enterprise licenses are very expensive (per-vCPU pricing). When the company already owns licenses through Software Assurance, using BYOL is significantly cheaper. Option D is wrong because Cloud SQL includes licensing in its pricing -- you cannot bring your own license to Cloud SQL. You would be double-paying. Option E is wrong because Microsoft licensing requires dedicated hosts (sole-tenant) for BYOL in the cloud; running SQL Server BYOL on standard multi-tenant Compute Engine instances violates Microsoft licensing terms.
+The stem specifies Software Assurance, which is what makes this answerable. SQL Server is an application server product eligible for **License Mobility through Software Assurance**, so the licenses can move to standard multi-tenant Compute Engine with no dedicated hardware requirement. That is the cheapest way to reuse the licenses they already own. Migrating to AlloyDB (PostgreSQL-compatible) is the other lever, eliminating SQL Server licensing entirely if the application can be adapted. Option A is wrong because Google-provided SQL Server Enterprise licensing is charged per vCPU and is expensive when you already own licenses. Option B is wrong because sole-tenant nodes are not required here: sole-tenancy is what you need under **Outsourcing Software Management Rights** (the route for customers *without* License Mobility), and using it anyway adds a sole-tenancy premium for no licensing benefit. Option D is wrong because Cloud SQL bundles licensing into its price, so paying separately means paying twice.
+
+**Exam tip:** on Microsoft licensing questions, find out whether the stem mentions Software Assurance. With SA you get License Mobility and multi-tenant is fine; without it you are into Outsourcing Software Management Rights and sole-tenant nodes. Windows Server OS licenses behave differently from application server licenses like SQL Server. See [Microsoft licensing on Compute Engine](https://cloud.google.com/compute/docs/instances/windows/ms-licensing).
 </details>
 
 ---

--- a/gcp/pca/questions/section-2-provisioning-infrastructure.md
+++ b/gcp/pca/questions/section-2-provisioning-infrastructure.md
@@ -45,7 +45,7 @@ Partner Interconnect is ideal when you need private connectivity to Google Cloud
 ### Q3. You are designing a network for a SaaS platform that serves customers globally. The platform has backend services in us-central1 and europe-west1. You need to route users to the closest healthy backend with a single anycast IP address. Which load balancer should you use?
 
 A) Regional external Application Load Balancer
-B) Global external Application Load Balancer (Classic)
+B) Global external Application Load Balancer
 C) Global external proxy Network Load Balancer
 D) Regional internal passthrough Network Load Balancer
 
@@ -281,7 +281,7 @@ Bigtable replication provides automatic, near-real-time replication between clus
 
 ---
 
-### Q17. A startup wants to migrate 200 TB of on-premises data to Cloud Storage. Their internet bandwidth is 1 Gbps. They need the data migrated within 2 weeks. Which transfer method should you recommend?
+### Q17. A startup wants to migrate 200 TB of on-premises data to Cloud Storage. Their internet bandwidth is 1 Gbps. They need the data migrated within 30 days. Which transfer method should you recommend?
 
 A) Use gsutil rsync over the internet
 B) Use Transfer Appliance
@@ -293,7 +293,9 @@ D) Use a Dedicated Interconnect provisioned for the migration
 
 **Correct: B)**
 
-At 1 Gbps, transferring 200 TB over the internet would take approximately 18.5 days (200 TB * 8 bits / 1 Gbps / 86400 seconds), exceeding the 2-week deadline even at 100% utilization, which is unrealistic. Transfer Appliance is a physical device shipped to your data center that you load with data and ship back to Google, supporting up to 300 TB per appliance and completing large transfers within days of Google receiving the device. Option A (gsutil) uses internet bandwidth and would exceed the deadline. Option C (Storage Transfer Service) also uses internet bandwidth with the same time constraint. Option D (Dedicated Interconnect) takes weeks to provision and is expensive for a one-time migration.
+At 1 Gbps, transferring 200 TB over the internet takes roughly 18.5 days at 100% link utilization (200 TB * 8 bits / 1 Gbps / 86400 seconds), and no production link sustains 100%. Realistically this overruns 30 days while also saturating the company's only internet connection for a month. Transfer Appliance is a physical device shipped to your data center, loaded, and shipped back; the TA300 model holds 300 TB, and the full round trip plus ingest fits inside 30 days. Option A (gsutil) is the same internet-bandwidth constraint, plus `gcloud storage` has superseded gsutil. Option C (Storage Transfer Service) also moves data over the network, so it hits the same ceiling. Option D (Dedicated Interconnect) takes weeks to provision and is heavy capital work for a one-time move.
+
+**Exam tip:** do the bandwidth arithmetic before picking. Divide the data volume by the link rate, then assume you only get 50-70% of nominal throughput. If the result is a meaningful fraction of the deadline, the answer is Transfer Appliance. Current models are TA40 (40 TB) and TA300 (300 TB).
 </details>
 
 ---
@@ -370,7 +372,7 @@ Cloud Run is the best fit for a containerized application with variable traffic 
 ### Q22. A gaming company needs to run game servers that require consistent, high single-thread performance and low latency. The servers are stateful and each instance handles up to 64 concurrent player connections. Which Compute Engine machine family should you recommend?
 
 A) E2 general-purpose (cost-optimized)
-B) C3D compute-optimized
+B) C2D compute-optimized
 C) N2 general-purpose with sole-tenant nodes
 D) M3 memory-optimized
 
@@ -379,7 +381,9 @@ D) M3 memory-optimized
 
 **Correct: B)**
 
-C3D (and C3) compute-optimized machine types deliver the highest per-core performance in Compute Engine, with sustained all-core turbo frequencies. Game servers that depend on high single-thread performance and low latency benefit directly from compute-optimized instances. Option A (E2) uses shared-core and burstable configurations that deliver inconsistent performance. Option C (N2 with sole-tenant nodes) provides dedicated hardware for licensing or compliance but does not deliver higher per-core performance than C3D. Option D (M3 memory-optimized) is designed for in-memory databases and SAP workloads; while it provides large memory, its per-core performance focus is not as high as compute-optimized families.
+C2D is a compute-optimized machine family, built for sustained high per-core performance with all-core turbo frequencies. Game servers that depend on single-thread performance and low latency benefit directly from it. Option A (E2) uses shared-core and burstable configurations, so performance is inconsistent by design. Option C (N2 with sole-tenant nodes) buys dedicated physical hardware for licensing or compliance reasons; it does not raise per-core performance. Option D (M3 memory-optimized) targets in-memory databases and SAP, trading per-core speed for memory capacity.
+
+**Exam tip:** know which family is which, because the exam leans on it. Compute-optimized is H3, H4D, C2 and C2D. C3, C3D, C4, N2 and E2 are general-purpose despite C3/C4 sounding like the C2 line. M-series is memory-optimized. "Consistent high single-thread performance" means compute-optimized; "large in-memory dataset" means memory-optimized.
 </details>
 
 ---
@@ -438,7 +442,7 @@ GKE Enterprise (formerly Anthos) provides fleet management for centralized visib
 ### Q26. You are designing a GKE architecture for a fintech company. They need to ensure that their Kubernetes workloads meet PCI-DSS compliance requirements. The cluster must provide workload isolation, binary authorization for container images, and network policy enforcement. Which configuration should you use?
 
 A) GKE Autopilot with Binary Authorization enabled
-B) GKE Standard with GKE Sandbox (gVisor), Binary Authorization, and Calico network policies enabled
+B) GKE Standard with GKE Sandbox (gVisor), Binary Authorization, and Dataplane V2 network policies enabled
 C) GKE Standard with default settings and namespace-level RBAC
 D) Cloud Run with container image signing
 
@@ -447,7 +451,9 @@ D) Cloud Run with container image signing
 
 **Correct: B)**
 
-GKE Sandbox (gVisor) provides an additional layer of workload isolation by running containers in a sandboxed kernel, which is important for PCI-DSS compliance where multi-tenant workload isolation is required. Binary Authorization ensures only trusted, signed container images are deployed. Calico network policies (enabled via the `--enable-network-policy` flag) enforce pod-to-pod traffic restrictions. Together, these features address the three compliance requirements. Option A (Autopilot) supports Binary Authorization and has built-in security hardening but does not support GKE Sandbox for the deepest workload isolation. Option C (default GKE Standard) lacks all three required features. Option D (Cloud Run) does not support network policies or GKE Sandbox-level isolation.
+Option B is the only choice that explicitly addresses all three stated requirements. GKE Sandbox (gVisor) runs containers against a user-space kernel, which is the workload isolation PCI-DSS asks for in multi-tenant clusters. Binary Authorization gates deployment on signed, attested images. Dataplane V2 (Cilium/eBPF) enforces pod-to-pod network policy and is the recommended plugin; Calico is the legacy dataplane. Option A is incomplete rather than impossible: Autopilot does support GKE Sandbox, Binary Authorization, and network policy via Dataplane V2 by default, but the option as written enables only Binary Authorization and says nothing about isolation or network policy, so it does not answer two of the three requirements. Option C (default Standard) has none of the three. Option D (Cloud Run) supports Binary Authorization but offers neither Kubernetes network policy nor gVisor-level workload isolation.
+
+**Exam tip:** be careful with "Autopilot cannot do X" reasoning. Autopilot supports GKE Sandbox, Spot Pods, GPUs, DaemonSets and network policy, and much older study material says otherwise. The genuine Standard-only cases are node-level access: custom sysctls, privileged DaemonSets, and specific node OS or kernel tuning. See the [Autopilot and Standard comparison](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison).
 </details>
 
 ---
@@ -506,7 +512,7 @@ pd-ssd (SSD Persistent Disk) provides consistent, sub-millisecond latency for ra
 ### Q30. Your company needs to run 100 parallel rendering jobs. Each job requires 96 vCPUs, 360 GB of RAM, and 4 NVIDIA T4 GPUs, and runs for approximately 4 hours. Jobs can be checkpointed and restarted. What is the most cost-effective compute configuration?
 
 A) 100 n2-highmem-96 instances with T4 GPUs attached, using on-demand pricing
-B) 100 a2-highgpu-4g instances using Spot VMs with checkpointing to Cloud Storage
+B) 100 n1-custom instances with 4 T4 GPUs attached, using Spot VMs with checkpointing to Cloud Storage
 C) GKE Autopilot with GPU node pools
 D) 100 c2d-highcpu-112 instances without GPUs, using software rendering
 
@@ -515,7 +521,9 @@ D) 100 c2d-highcpu-112 instances without GPUs, using software rendering
 
 **Correct: B)**
 
-A2 instances are optimized for GPU workloads and come with NVIDIA A100 GPUs. However, for T4 GPUs, you would use N1 or custom machine types with T4 GPUs attached as Spot VMs. The key insight is that since jobs can be checkpointed and restarted, Spot VMs provide up to 91% cost savings. Checkpointing progress to Cloud Storage ensures that preempted jobs can resume rather than restart from scratch. Option A (on-demand) costs 60-91% more than Spot VMs for the same configuration. Option C (GKE Autopilot) adds Kubernetes overhead for simple batch jobs and provides less control over GPU VM selection. Option D (software rendering without GPUs) would take dramatically longer and likely cost more in compute hours despite not paying for GPUs.
+T4 GPUs attach to N1 machine types, so an N1 custom configuration is what actually satisfies the stated 96 vCPU / 360 GB / 4x T4 requirement. The decisive fact is that the jobs are checkpointable and restartable, which is exactly the workload profile Spot VMs are priced for: 60-91% off on-demand, at the cost of preemption with 30 seconds notice. Checkpointing to Cloud Storage means a preempted job resumes instead of restarting. Option A specifies the right hardware but pays on-demand rates for a workload that tolerates preemption, so it is several times more expensive for no benefit. Option C (Autopilot) adds Kubernetes for what is a plain batch workload, and gives less direct control over GPU and machine selection. Option D drops the GPUs entirely; software rendering would run far longer and cost more in CPU hours than the GPUs saved.
+
+**Exam tip:** match the accelerator to the machine family before comparing prices. T4 and V100 attach to N1; A100 comes with A2; H100 with A3; L4 with G2. An option pairing an A2 machine with a T4 requirement is wrong on hardware alone, whatever its pricing story. Then look for "checkpointable", "fault-tolerant" or "can be restarted", which is the exam signalling Spot.
 </details>
 
 ---
@@ -532,12 +540,12 @@ D) GKE Autopilot with DaemonSets to configure kernel parameters
 
 **Correct: B)**
 
-GKE Standard is required when workloads need custom kernel parameters (sysctl settings), privileged containers, or other node-level customizations that Autopilot restricts for security. Autopilot manages the nodes entirely and does not allow sysctl modifications or privileged access. While the team has limited Kubernetes expertise, the custom kernel parameter requirement makes Standard the only viable GKE option. The team should invest in Kubernetes training or use managed services like Config Sync for operational simplification. Option A (Autopilot) cannot accommodate the sysctl requirement. Option C (Cloud Run) cannot run 15 interconnected microservices with custom networking requirements as effectively as GKE. Option D is incorrect because Autopilot restricts DaemonSets to system-level add-ons and does not allow custom sysctl modifications.
+GKE Standard is required when workloads need custom kernel parameters (sysctl settings), privileged containers, or other node-level customizations that Autopilot restricts for security. Autopilot manages the nodes entirely and does not allow sysctl modifications or privileged access. While the team has limited Kubernetes expertise, the custom kernel parameter requirement makes Standard the only viable GKE option. The team should invest in Kubernetes training or use managed services like Config Sync for operational simplification. Option A (Autopilot) cannot accommodate the sysctl requirement. Option C (Cloud Run) cannot run 15 interconnected microservices with custom networking requirements as effectively as GKE. Option D is incorrect because the sysctl requirement is the blocker, not DaemonSets: Autopilot does run user DaemonSets, but it does not permit custom kernel parameter changes. The allowlist people remember applies to privileged workloads, not to DaemonSets generally.
 </details>
 
 ---
 
-### Q32. You are designing a compute solution for a scientific simulation that requires 4 TB of RAM and 224 vCPUs. The simulation runs for 72 hours and the dataset must remain in memory throughout. Which machine type family should you use?
+### Q32. You are designing a compute solution for a scientific simulation that requires 3 TB of RAM and 128 vCPUs. The simulation runs for 72 hours and the dataset must remain in memory throughout. Which machine type family should you use?
 
 A) N2 general-purpose with extended memory
 B) M3 memory-optimized
@@ -549,7 +557,9 @@ D) A3 accelerator-optimized
 
 **Correct: B)**
 
-M3 memory-optimized machine types offer up to 30 TB of memory, making them ideal for workloads that require extremely large in-memory datasets. The m3-megamem-128 provides 128 vCPUs and 1.9 TB of RAM, while the m3-ultramem-128 provides up to 3.8 TB. For 4 TB of RAM with 224 vCPUs, you would use a combination or the largest M3 configuration available. Option A (N2 with extended memory) supports custom memory configurations but maxes out well below 4 TB per instance. Option C (C3 compute-optimized) is optimized for CPU performance and does not offer the memory capacity needed. Option D (A3 accelerator-optimized) is designed for GPU workloads and does not provide 4 TB of system memory.
+The M-series is the memory-optimized family, built for workloads whose dataset must stay resident in RAM. `m3-ultramem-128` provides 128 vCPUs with roughly 3.9 TB of memory, which covers the stated 3 TB / 128 vCPU requirement in a single instance. Option A (N2 with extended memory) allows custom memory ratios but tops out well below 3 TB per instance. Option C (C3) is general-purpose despite the name and is tuned for per-core throughput, not memory capacity. Option D (A3 accelerator-optimized) exists to carry H100 GPUs; its system memory is sized to feed the accelerators, not to hold a multi-terabyte working set.
+
+**Exam tip:** for memory questions, check the ceiling of the family you pick against the number in the stem. M3 reaches about 3.9 TB, M2 about 12 TB, M4 up to 6 TB with 224 vCPUs, and X4 goes higher still. If a scenario needs both very high memory and very high vCPU counts, M3 is often the wrong pick, because its vCPU count caps at 128.
 </details>
 
 ---

--- a/gcp/pca/questions/section-3-security-compliance.md
+++ b/gcp/pca/questions/section-3-security-compliance.md
@@ -753,7 +753,7 @@ IAP integrates with Access Context Manager to enforce context-aware access. You 
 
 ---
 
-### Q40. You need to enable OS Login for all Compute Engine VMs in the production project to centrally manage SSH access. Some team members need root access on specific VMs while others should have standard user access. How should you configure this? (Choose TWO.)
+### Q40. You need to enable OS Login for all Compute Engine VMs in the production project to centrally manage SSH access. Some team members need root access on specific VMs while others should have standard user access. How should you configure this? (Choose THREE.)
 
 A) Enable OS Login at the project level by setting the `enable-oslogin` metadata key to `TRUE`
 B) Grant `roles/compute.osLogin` to team members who need standard user access
@@ -764,13 +764,9 @@ E) Grant `roles/compute.instanceAdmin.v1` to all team members
 <details>
 <summary>Answer</summary>
 
-**Correct: A) and B) + C) (select A and whichever login role applies; the question asks for TWO, so A plus either B or C -- but since both B and C are needed for the full solution, the best TWO are A and C if root is required, or A and B for standard users)**
+**Correct: A), B) and C)**
 
-Actually, let me clarify: **A), B), and C)** are all correct actions in the full solution. Since the question asks for TWO and describes both user types, the best two answers that enable the overall solution are:
-
-**Correct: A) and C)**
-
-OS Login must be enabled at the project level (A) by setting the metadata flag. Then, `roles/compute.osAdminLogin` (C) provides root/sudo access for those who need it, while `roles/compute.osLogin` (B) provides standard access. Since the question specifically highlights root access as a requirement, C is the more critical role to select alongside A. Option D -- manual SSH key management is what OS Login replaces. Option E -- `instanceAdmin.v1` grants VM management permissions, not SSH access.
+The scenario describes two classes of user, so the complete solution needs the switch plus both roles. A enables OS Login project-wide via the `enable-oslogin` metadata key, which is the prerequisite for either role to do anything. B grants `roles/compute.osLogin` for standard, non-sudo SSH. C grants `roles/compute.osAdminLogin` for the users who need root. Option D is wrong because per-user SSH keys in project metadata are exactly the practice OS Login replaces; keys in metadata are not centrally revocable and do not follow the IAM lifecycle. Option E is wrong because `roles/compute.instanceAdmin.v1` confers VM management rights (start, stop, delete, change machine type) and does not by itself grant SSH access, so granting it to all team members hands out destructive permissions while still not solving the login problem.
 
 **Exam tip:** OS Login roles: `compute.osLogin` = standard SSH (no sudo), `compute.osAdminLogin` = SSH with sudo. OS Login replaces SSH key management with IAM-based access. Both require the `enable-oslogin` metadata flag.
 </details>

--- a/gcp/pca/questions/section-5-managing-implementations.md
+++ b/gcp/pca/questions/section-5-managing-implementations.md
@@ -209,13 +209,15 @@ D) Set up a VPN and use `gcloud storage cp` for the transfer
 <details>
 <summary>Answer</summary>
 
-**Correct: A)**
+**Correct: B)**
 
-At 100 Mbps, transferring 5 TB takes approximately 4.6 days -- acceptable for critical data. `gsutil -m rsync` (or `gcloud storage rsync`) provides multi-threaded, resumable transfer with incremental sync capability. If any files change during transfer, re-running rsync only transfers the differences. This gets critical data to GCP quickly.
+Storage Transfer Service supports on-premises and private file systems through **agent-based transfers**: you run a fleet of transfer agents inside your network, and Google manages the parallelism, retries, checkpointing, and integrity verification. It is the documented choice for on-premises transfers above roughly 1 TiB, which 5 TB clearly exceeds. At 100 Mbps the move takes around 4.6 days, so it will run unattended across several days and survive interruptions without a human restarting it.
 
-- **B) is wrong** -- Storage Transfer Service is designed for large-scale, scheduled transfers from other cloud providers (AWS S3, Azure) or HTTP/HTTPS sources, not for on-premises data sources. For on-premises to Cloud Storage, `gsutil`/`gcloud storage` or Transfer Appliance are the tools.
-- **C) is wrong** -- Waiting delays the migration of critical data unnecessarily. Transfer Appliances can take weeks for shipping and processing. The 5 TB can be transferred in under a week over the existing connection.
-- **D) is wrong** -- A VPN provides secure network connectivity but doesn't speed up the transfer. `gcloud storage cp` works but `gsutil -m rsync` is better because it's incremental and handles restarts gracefully. Also, VPN setup adds time.
+- **A) is workable but is not the recommended tool at this size** -- `gsutil -m rsync` is multi-threaded and resumable, but it runs from one machine, needs someone to restart it after a failure, and gsutil is being retired from the gcloud CLI bundle in March 2027. For a multi-day, multi-terabyte transfer the managed agent fleet is the better answer, and `gcloud storage rsync` is the successor for the ad-hoc case.
+- **C) is wrong** -- Waiting delays critical data for no reason. The appliance round trip takes weeks; 5 TB moves over the existing link in under a week, and the whole point of the question is that the two can run in parallel.
+- **D) is wrong** -- A VPN adds encryption and setup time but no throughput. The 100 Mbps link is the constraint, and a VPN does not widen it.
+
+**Exam tip:** Storage Transfer Service is not cloud-to-cloud only. It has three modes: agent-based (on-premises and private file systems), agentless (S3, Azure Blob, HTTP/HTTPS sources), and Cloud Storage to Cloud Storage. "On-premises means STS is wrong" is a common misconception and the exam tests it. See [Storage Transfer Service overview](https://cloud.google.com/storage-transfer/docs/overview).
 
 **Exam tip:** Data migration tool selection: <10 TB + decent bandwidth = gsutil/gcloud storage. 10-200 TB = Storage Transfer Service (cloud-to-cloud) or Transfer Appliance. 200+ TB = Transfer Appliance. Know the bandwidth calculation: 1 TB at 100 Mbps ~ 22 hours.
 


### PR DESCRIPTION
## Summary

- A full fact-check of the PCA material against `cloud.google.com` found answer keys that teach incorrect facts. This PR fixes those first, ahead of the wider errata, because practising against a wrong key actively trains the wrong answer.
- 11 answer keys corrected across sections 1, 2, 3 and 5.
- 2 explanations corrected because the new text would otherwise contradict them.
- Every corrected question gains an exam tip naming the trap, and cites the official doc where a fact was disputed.

## What was wrong

| Question | Problem |
|---|---|
| Q18 (s1) | WebSocket LB marked the proxy Network LB. The Application LB is the documented WebSocket product and proxies the upgrade with zero configuration. |
| Q23 (s1) | Option A named "Cloud Load Test", which is not a Google Cloud product. |
| Q49 (s1) | Option E marked wrong on the claim BYOL requires sole-tenant nodes. The stem specifies Software Assurance, so License Mobility applies. |
| Q3 (s2) | Marked answer named the Classic global external Application LB, the legacy product. |
| Q17 (s2) | No option met the stated 2-week deadline; the appliance round trip also overruns it. |
| Q22 (s2) | C3D labelled compute-optimized. C3/C3D are general-purpose. |
| Q26 (s2) | Rejected Autopilot on the false basis that it cannot run GKE Sandbox. |
| Q30 (s2) | Required 4x T4 but marked an A100 machine type. The explanation admitted the mismatch. |
| Q32 (s2) | Required 4 TB RAM and 224 vCPUs, which M3 cannot deliver. The explanation also claimed M3 offers 30 TB, wrong by about 7x. |
| Q40 (s3) | Answer block contained raw model reasoning and three conflicting verdicts, and was unanswerable as a two-pick. |
| Q8 (s5) | Rejected Storage Transfer Service on the false claim it cannot read on-premises sources. |

## Also fixed

- Firestore multi-region described as eventually consistent (Q22, section 1). Reads are strongly consistent by default; the real discriminator is write latency to the leader region.
- Autopilot described as restricting DaemonSets (Q31, section 2). The allowlist applies to privileged workloads; the genuine blocker in that question is custom sysctls.

## Not in this PR

The audit covered all 10 study guides, all 260 questions and the exam README. The remaining findings are recorded as a prioritised backlog in `.claude/state/research/2026-08-09-pca-content-audit.md`, including:

- Non-existent gcloud commands presented as real, notably `gcloud monitoring slos` inside the SLO objective.
- A 1000x unit error on Hyperdisk throughput and a 1000x error on BigQuery streaming insert pricing.
- The Vertex AI to Gemini Enterprise Agent Platform rebrand, which sits inside four marked-correct answers and needs a decision rather than a find-and-replace, since the v6.1 exam guide still uses the old names.
- Section weights in `gcp/pca/README.md` that appear to be unsourced, since Google does not publish per-section percentages for PCA.