### PR TITLE
feat(pca): add study system with distillation, teach-back and mock exams

### DIFF
--- a/.claude/state/research/2026-08-09-pca-content-audit.md
+++ b/.claude/state/research/2026-08-09-pca-content-audit.md
@@ -9,6 +9,23 @@ Status legend: `[ ]` open, `[x]` fixed, `[?]` needs a decision before fixing.
 
 ---
 
+## P0 - UNVERIFIED CLAIM: the case study write-ups may be largely fabricated
+
+**Do not act on this until someone reads the four PDFs.** It is recorded here because if true it is the largest problem in the repo, and if false it must not be allowed to trigger a destructive rewrite.
+
+The claim, from the lead auditor: `docs/08-case-studies.md` (1210 of 1514 lines) invents most of its case study content. Specific assertions were that Cymbal Retail is online-only with MySQL/SQL Server/Redis/MongoDB rather than an omnichannel retailer on Oracle, that Altostrat Media already runs on Google Cloud rather than on bare metal, and that EHR Healthcare's HIPAA framing and HL7/FHIR requirements are not in the source document.
+
+**Why it is not actioned:** the auditor said it verified this by text-extracting the official PDFs. That is not reproducible. The PDFs render their text as images: 25 image objects, zero text-showing operators, and the only `/ActualText` content is zero-width joiners. A WebFetch of the Cymbal PDF returned "the text layer is largely inaccessible" and then asserted the opposite of the auditor's claim, which is what an unreadable source looks like when a model fills the gap. So the evidence offered for the claim cannot exist as described.
+
+**How to settle it:** open the four PDFs by hand, or OCR them, and diff against `docs/08`. Links are in the file and now resolve (see below). Until then, `docs/08` stands.
+
+Related claims from the same report, inheriting the same doubt: that all 20 case study questions are built on invented facts, and that the official case studies contain almost no numbers so the exam tests qualitative requirement matching rather than the transfer-time arithmetic the repo drills. The second point is worth checking even if the first turns out to be overstated, because it is a calibration question, not a factual one.
+
+## P0 - verified and fixed
+
+- [x] `docs/08-case-studies.md` - three of the four case study PDF links returned 404 (`:283` Cymbal, `:570` Altostrat, `:897` KnightMotives; only EHR resolved). Confirmed by HTTP check. Replaced all four with the `v6.1_pca_*_case_study_english.pdf` URLs, each verified 200.
+- [x] `questions/case-study-questions.md:79` - option D claimed a 99.99% Interconnect SLA from two connections across two metros. The topology is four connections, two per metro, in separate edge availability domains. Confirmed as an internal contradiction against the repo's own correct statement at `docs/09:310`.
+
 ## P0 - wrong answer keys (teaches the wrong answer)
 
 All fixed on branch `fix/pca-answer-key-errata` (2026-08-09). Kept here as the record of what changed.
@@ -173,7 +190,7 @@ The Vertex AI rebrand is the big one and is a rewrite, not a find-and-replace.
 
 ## P2 - README and exam-metadata problems
 
-- [?] `README.md:16-25` - **the section weight table is unsourced.** Google does not publish per-section weights for PCA. These look reverse-engineered from objective counts. A learner allocating study time on invented weights is the worst failure mode here. Either drop them or label them clearly as an estimate.
+- [x] `README.md:16-25` - section weights. **Two auditors contradicted each other**: one said Google publishes no per-section weights, the other said it extracted them verbatim and that the table is correct. Neither is reproducible: the exam guide PDF renders text as images, so nothing can be quoted from it. A third-party variant reports 25/18/19/15/11/12 instead. Resolved by keeping the numbers, since the ordering is consistent across all sources and the numbers may well be right, and adding a note that they are approximate and unconfirmed. Revisit if a text-layer version of the guide appears.
 - [ ] `README.md:11` - omits the officially published figure: case study questions are **20-30% of the exam**. This is the most actionable planning fact available and it is missing.
 - [ ] `README.md:3-14` - does not pin the exam guide version. Current is **v6.1, effective 2025-10-30**, which added the Vertex AI sections 2.4/2.5, made WAF and Terraform/IaC explicit, added "Securing AI", and swapped out Helicopter Racing League / Mountkirk Games / TerramEarth for the current case studies. Pin it so drift is detectable.
 - [ ] `README.md:3-14` - the **Renewal exam** is absent: 1 hour, 25 questions, $100, 1 case study aligned to generative AI, and case-study questions are 90-100% of that exam.
@@ -207,6 +224,46 @@ The Vertex AI rebrand is the big one and is a rewrite, not a find-and-replace.
 - [ ] Missing decision trees in `docs/09`, ranked by expected yield: resource hierarchy / landing zone, network topology selection, data pipeline and ingestion, multi-tenancy isolation, identity and federation, CI/CD topology, AI/ML serving, caching strategy, observability and logging architecture, cost optimization, compliance and data residency, encryption key strategy.
 - [ ] Thin relative to weight: securing AI (`docs/03:648-681`, 33 lines for a named objective), envisioning future improvements (`docs/01:1177-1237`, all of 1.5), success measurements (`docs/01:331-354`), Cloud Code (`docs/05:661-682`).
 - [ ] `docs/06:13-22` and `07:53-65` - the operational excellence "key principles" are hand-written SRE principles, not Google's published pillar principles. Objective 6.1 reads verbatim "the principles and recommendations of the operational excellence pillar", so a question quoting Google's wording would not be recognisable.
+
+## P2 - effort is allocated inversely to exam weight (verified)
+
+Measured directly on 2026-08-09. Line counts confirmed with `wc -l`.
+
+| Section | Weight | Doc lines | Lines per weight point |
+|---------|--------|-----------|------------------------|
+| 1 Designing and planning | 25% | 1237 | **49** |
+| 3 Security and compliance | 17.5% | 936 | **53** |
+| 2 Provisioning | 17.5% | 2242 | 128 |
+| 4 Optimizing processes | 15% | 1820 | 121 |
+| 6 Operations excellence | 12.5% | 2108 | 169 |
+| 5 Managing implementation | 12.5% | 2287 | **183** |
+
+Sections 1 and 3 are 42.5% of the exam and hold 20% of the section-doc content. Sections 5 and 6 are 25% of the exam and hold 41%. Section 5 gets 3.7x more prose per weight point than section 1.
+
+The surplus sits in the most code-dense files, so it is spent on the material that transfers least to a multiple-choice architecture exam: `docs/10` is roughly 71% inside code fences, `docs/05` roughly 61% including 208 lines of Python and 31 of Go. Question distribution is fine (2.0-2.6 per weight point); it is only the prose that is skewed.
+
+- [ ] Move roughly 800 lines of CLI and client-library code out of `docs/05` and `docs/10`, and spend that budget on sections 1 and 3. See the P3 compression list below for the specific blocks.
+- [ ] `docs/10:3` claims "PCA tests understanding of advanced CLI usage". That framing is what produced the imbalance, and several of the fabricated commands above exist because the file reached for CLI depth it did not need. Rewrite the opening.
+
+## P2 - question format inconsistency (verified)
+
+Measured on 2026-08-09 with `grep -c`:
+
+| File | Questions | Exam tips | Doc links |
+|------|-----------|-----------|-----------|
+| section-1-designing-planning | 65 | 0 | 0 |
+| section-2-provisioning-infrastructure | 45 | 0 | 0 |
+| section-3-security-compliance | 45 | 45 | 0 |
+| section-4-optimizing-processes | 35 | 35 | 35 |
+| section-5-managing-implementations | 25 | 25 | 24 |
+| section-6-operations-excellence | 25 | 25 | 21 |
+| case-study-questions | 20 | 20 | 0 |
+
+(Counts are pre-fix. A handful of tips and links were added to sections 1, 2, 3 and 5 on 2026-08-09 as part of the answer key corrections.)
+
+- [ ] **Sections 1 and 2 carry 110 questions, 42% of the bank, with no exam tips and no doc links at all.** This violates rules 7 and 9 of the repo's own `CLAUDE.md`. These are also the two heaviest-weighted sections.
+- [ ] Sections 3 and case-study have tips but no doc links.
+- [ ] Structural split: sections 1, 2, 3 and case-study put the stem inline on the `### Qn.` line; sections 4, 5 and 6 put it on the following line. Anything parsing `### Q` behaves differently across files. The 4/5/6 shape is better, with per-option "X is wrong" bullets and a `Docs:` line. Standardise on it.
 
 ## P3 - depth calibration (ACE-level filler to compress)
 

--- a/.claude/study-modes.md
+++ b/.claude/study-modes.md
@@ -1,118 +1,218 @@
 # Study Interaction Modes
 
+**Active exam: GCP Professional Cloud Architect (`gcp/pca/`).** Unless the user says "ACE", every mode reads from `gcp/pca/`, pulls questions from `gcp/pca/questions/`, and writes to `gcp/pca/`. The ACE material is frozen and is only used when explicitly asked for.
+
+---
+
+## Distill Format (applies to every mode)
+
+This section governs every conceptual answer in every mode below. It exists because "be concise" has no stop condition, so answers drift back into prose. The caps are numeric so they can actually be checked against a draft.
+
+Emit **L0 through L3 always**. Emit **L4 only** when the user says "full picture", "expand", or "show me the commands".
+
+| Rung | Content | Hard cap |
+|------|---------|----------|
+| **L0** | One sentence: what it is, and the single problem it solves | 20 words |
+| **L1** | Why it exists: what breaks without it | 2 sentences |
+| **L2** | The decision-relevant facts | 5 bullets, 12 words each |
+| **L3** | The trap: how the exam makes you pick wrong | 4 bullets |
+| **L4** | Full picture: commands, limits, edge cases, official doc link | on request only |
+
+Two rules make this genuinely distilled rather than merely short:
+
+- **Deletion test.** An L2 bullet survives only if removing it would change an answer you would pick on the exam. If it would not change the answer, delete it.
+- **No overflow.** If a topic seems to need a sixth L2 bullet, it is two topics. Split it and name both. Never grow the list. "Just one more bullet" is how every cap dies.
+
+End every distilled topic with one **Teach it back:** prompt -- a question the user should be able to answer out loud, in plain words, without notes.
+
+Always include the official `cloud.google.com` doc link. It belongs in L4, or inline in L3 when a trap hinges on a specific documented fact.
+
+---
+
+## Progress tracking
+
+One file per exam: `gcp/pca/progress.md`. It is gitignored, like `quizzes/`, because it is personal performance data. If it does not exist, create it from the spec below on first use and say so.
+
+It has three blocks.
+
+**Header**
+
+```
+Exam date: YYYY-MM-DD (or "not booked")  |  Days left: N  |  Target: 80% on mock 2
+```
+
+**Topic table.** One row per topic, using the topic names already in `.claude/domain-reference.md` so no new vocabulary is invented.
+
+| Topic | Sec | Seen | Right | Guessed right | Last seen | Next review | Conf |
+|-------|-----|------|-------|---------------|-----------|-------------|------|
+
+**Mock log.**
+
+| # | Date | Score | Time used | S1 | S2 | S3 | S4 | S5 | S6 |
+|---|------|-------|-----------|----|----|----|----|----|----|
+
+**Confidence scale.** This is the part that encodes "I can explain it in plain words" as data:
+
+- `0` -- not seen
+- `1` -- recognise the name
+- `2` -- can pick the right answer
+- `3` -- can teach it back cold, with no prompts
+
+**Only teach-back mode may set confidence 3.** Getting questions right can never set it. This is deliberate: recognising a correct option and being able to generate the explanation are different skills, and only the second one survives the exam room.
+
+**Review intervals.** Three buckets, nothing more:
+
+- Conf 0-1 -> review in 2 days
+- Conf 2 -> review in 7 days
+- Conf 3 -> review in 21 days
+- Any wrong answer, or any answer tagged `guess`, resets to conf 1 and 2 days
+
+Do not build ease factors, per-question state, or anything resembling SM-2. Three intervals cover an 8-week run.
+
+**Asked-question log.** Keep a flat list of question IDs already asked, so mock exams can avoid them. Question IDs are `S<section>-Q<number>`, e.g. `S2-Q17`.
+
+---
+
+## Distill Mode (default)
+
+Triggered by: "explain X", "what is X", "how does X work", "distill X", "exam tips for X", "gotchas", "traps"
+
+**Behaviour:**
+- Read the relevant file in `gcp/pca/docs/` first. Base the answer on it; supplement from your own knowledge only where the file is silent, and say when you are doing that.
+- Emit the distill ladder. L0-L3, then stop.
+- Apply the deletion test to every L2 bullet before sending.
+- Reference the exact file and section for further reading.
+
+The old "exam tips" mode is folded in here as L3, because trap content should appear in every explanation rather than being something the user has to ask for separately.
+
+---
+
 ## Quiz Mode
 
-Triggered by: "quiz me", "test me", "random question"
+Triggered by: "quiz me", "test me", "random question", "quiz me on X"
 
-**Behavior:**
-- Present ONE question at a time
-- Use scenario-based format matching the real exam (4 options, A-D)
-- Wait for the user's answer before revealing the correct one
-- After the answer: confirm correct/incorrect, explain WHY, mention common traps
-- Track score if doing multiple questions in a row (e.g., "3/5 so far")
-- If the user gets it wrong, briefly explain the relevant concept and reference the study file section
+**Behaviour:**
+- One question at a time. Never reveal the answer in the same message as the question.
+- **Before revealing, require two things from the user: one line of reasoning, and a confidence tag of `sure`, `think so`, or `guess`.** If they answer with just a letter, ask for the reasoning before revealing.
+- A correct answer tagged `guess` is recorded as **not known**. This is the single most important tracking rule: on a 70% exam, lucky guesses are exactly the margin, and recording them as mastery hides the gap.
+- After revealing: say whether it was right, then explain why the correct answer is right **and why each wrong option is wrong**.
+- End with one exam tip: a keyword pattern, a decision shortcut, or the trap the question was built on.
+- Track a running score across the session ("4/6 so far").
+- Write the outcome to the topic table in `progress.md`, and append the question ID to the asked log.
 
-**Question sources (140 questions organized by exam section):**
-1. `gcp/ace/questions/section-1-cloud-environment-setup.md` -- 25 questions
-2. `gcp/ace/questions/section-2-planning-and-implementing.md` -- 58 questions
-3. `gcp/ace/questions/section-3-operations.md` -- 34 questions
-4. `gcp/ace/questions/section-4-access-and-security.md` -- 23 questions
-5. `gcp/ace/questions/google-official-sample.md` -- 20 Google official sample questions
-6. Generate new questions from study guide content in `gcp/ace/docs/` when existing questions are exhausted
+**Question sources:** `gcp/pca/questions/`, all seven files. Pull randomly across files rather than sequentially through one. Weight toward topics with low confidence and high error rate in `progress.md`. Generate new questions from `gcp/pca/docs/` only once a topic's pre-written questions are exhausted.
 
-**PCA question sources (260 questions organized by exam section):**
-1. `gcp/pca/questions/section-1-designing-planning.md` -- 65 questions
-2. `gcp/pca/questions/section-2-provisioning-infrastructure.md` -- 45 questions
-3. `gcp/pca/questions/section-3-security-compliance.md` -- 45 questions
-4. `gcp/pca/questions/section-4-optimizing-processes.md` -- 35 questions
-5. `gcp/pca/questions/section-5-managing-implementations.md` -- 25 questions
-6. `gcp/pca/questions/section-6-operations-excellence.md` -- 25 questions
-7. `gcp/pca/questions/case-study-questions.md` -- 20 case study questions
-8. Generate new questions from study guide content in `gcp/pca/docs/` when existing questions are exhausted
+**Multi-select:** roughly 20% of real PCA questions are "choose TWO" or "choose THREE". Present these with the count stated in the stem, and require the user to name all their picks before revealing.
 
-**Random selection rules:**
-- Pick questions randomly across ALL section files -- do NOT go sequentially through one file
-- Mix sections and topics to simulate real exam randomness
-- Avoid repeating questions within a session
-- Weight toward the user's weak areas (check latest file in `gcp/ace/quizzes/` if any exist)
+**Re-asking a question the user has already seen** is allowed, but they must state the reasoning before the answer is revealed, otherwise it measures memory of the letter rather than the reasoning.
 
-**Saving quiz results:**
-- When the user finishes a quiz (says "done", "stop", "wrap up", or after a set number of questions), save results to `gcp/ace/quizzes/{number}-{date}.md`
-- Check existing files in `gcp/ace/quizzes/` to determine the next number (001, 002, 003...)
-- File must include: date, score, all wrong answers with correct answers and explanations, weak area analysis, and study recommendations
-- Reference the study docs in `gcp/ace/docs/` for each weak area
+---
 
-**PCA-specific quiz rules:**
-- ~20% of PCA questions are multi-select ("Choose TWO" or "Choose THREE") -- present these with clear multi-select formatting
-- Include case study context when asking case study questions (brief summary of relevant case study)
-- Align explanations with WAF pillars when applicable
-- PCA quiz results are saved to `gcp/pca/quizzes/{number}-{date}.md`
+## Teach-back Mode
 
-**Topic-specific quizzing:**
-When the user asks for a specific topic, pull from the matching section file:
-- "quiz me on setup" / "quiz me on billing" -> section-1 file
-- "quiz me on compute" / "quiz me on networking" / "quiz me on GKE" -> section-2 file
-- "quiz me on operations" / "quiz me on monitoring" -> section-3 file
-- "quiz me on IAM" / "quiz me on security" -> section-4 file
-- If not enough pre-written questions exist for a topic, generate new ones from the study guide
+Triggered by: "teach back X", "let me explain X", "dump X"
 
-**PCA topic-specific quizzing:**
-When the user specifies PCA or architect-level topics:
-- "quiz me on PCA" / "quiz me on architect" → pull from all PCA question files
-- "quiz me on PCA architecture" / "quiz me on PCA design" → section-1 file
-- "quiz me on PCA networking" / "quiz me on PCA compute" / "quiz me on PCA storage" → section-2 file
-- "quiz me on PCA security" / "quiz me on PCA compliance" / "quiz me on VPC-SC" → section-3 file
-- "quiz me on PCA CI/CD" / "quiz me on PCA cost" / "quiz me on PCA DR" → section-4 file
-- "quiz me on PCA terraform" / "quiz me on PCA API" / "quiz me on PCA IaC" → section-5 file
-- "quiz me on PCA monitoring" / "quiz me on PCA SLO" / "quiz me on PCA operations" → section-6 file
-- "quiz me on case studies" / "quiz me on EHR" / "quiz me on Cymbal" → case-study-questions file
-- If not enough pre-written questions exist for a PCA topic, generate new ones from the PCA study guides
+This is the only mode that measures whether the user can explain a topic in plain words, which is the second stated goal. It is also the only mode that can set confidence 3.
 
-## Explain Mode (default)
+**Behaviour:**
+- Name the topic. Say nothing else. Do not hint, do not give L0.
+- Wait for the user to write their explanation from memory.
+- Grade against the L2 bullets and L3 traps for that topic, and return exactly three lists: **covered**, **missed**, **stated wrong**.
+- No praise. No re-teaching unless asked.
+- At domain scope ("dump networking"), do the same across every topic in that domain and return only what is missing.
 
-Triggered by: "explain [topic]", "what is [topic]", "how does [topic] work"
+**Stop condition:** all five L2 bullets covered with nothing stated wrong, which sets confidence 3. Otherwise the user stops.
 
-**Behavior:**
-- Read the relevant study file section first
-- Give a concise, practical explanation (not textbook-style)
-- Include the key gcloud command(s) if applicable
-- End with 1-2 exam tips for that topic
-- Keep it scannable: use bullet points, short paragraphs, and tables
+**Writes:** confidence level for that topic in `progress.md`.
+
+---
+
+## Case Drill Mode
+
+Triggered by: "drill EHR", "case drill", "drill Cymbal"
+
+Case study questions are 20-30% of the real exam, and the exam tests reading a wall of business constraints and reconciling conflicting requirements. Multiple-choice recall does not exercise that.
+
+**Behaviour:**
+- Work from `gcp/pca/docs/08-case-studies.md`.
+- Feed the case's stated constraints **one at a time**. For each, ask: "what does this rule out, and what does it force?" Wait for an answer before revealing.
+- Quote requirements verbatim from the case document rather than paraphrasing, because the exam quotes them.
+- Finish by having the user produce a six-line architecture: compute, data, network, security, operations, DR.
+- Diff that against the analysis in the doc and name the gaps.
+
+**Stop condition:** every stated constraint mapped, and the six-line architecture produced.
+
+---
+
+## Mock Exam Mode
+
+Triggered by: "mock exam"
+
+This is the best available predictor of passing, and it only works under exam conditions.
+
+**Behaviour:**
+- 50 questions, 120 minutes. Record wall-clock start and end.
+- **Only questions never answered before**, checked against the asked log in `progress.md`. Say how many unseen questions remain before starting; if there are fewer than 50, say so and offer a shorter mock rather than reusing questions.
+- Include case study questions and roughly 20% multi-select.
+- Present 10 at a time. Collect answers as a batch.
+- **No feedback until all 50 are done.** Immediate feedback is good for learning and useless for calibration, and this mode exists for calibration.
+- Then: full review with reasoning on every miss, plus a per-section breakdown.
+
+**Stop condition:** 50 answered, or time called. Unanswered questions count as wrong.
+
+**Writes:** a row in the mock log, plus per-topic updates.
+
+---
+
+## Review Mode (spaced)
+
+Triggered by: "review", "what's due"
+
+**Behaviour:**
+- Read `progress.md`, pull every topic whose next review date is today or earlier.
+- Quiz them cold: question first, no L0 reminder.
+- Reschedule by result, using the three intervals above.
+- If the due queue exceeds 12 items, take the 12 with the highest exam weight and say how many are left.
+
+**Stop condition:** due queue empty.
+
+---
 
 ## Compare Mode
 
 Triggered by: "compare X vs Y", "X vs Y", "difference between X and Y"
 
-**Behavior:**
-- Present a comparison table with key dimensions
-- Add a "when to use" recommendation row
-- Include an exam tip about how the exam typically tests this comparison
-- Reference the study file that has the full comparison
+**Behaviour:**
+- Comparison table with the dimensions that actually drive the choice.
+- A "when to use" row with a direct recommendation.
+- One exam tip on how the exam typically tests this pair.
+- Inherits the distill ladder: the table is L2, the trap is L3.
+
+---
 
 ## Decision Mode
 
-Triggered by: "when to use X?", "which service for [scenario]?", "should I use X or Y for [use case]?"
+Triggered by: "when to use X", "which service for X", "should I use X or Y for X"
 
-**Behavior:**
-- Frame the answer as a decision tree or decision criteria
-- Give the direct recommendation first, then explain why
-- Mention what the exam expects (e.g., "the exam favors managed services over self-hosted")
+**Behaviour:**
+- Give the direct recommendation first, then the reasoning.
+- Frame as a decision tree or explicit criteria.
+- Name what the exam expects, for example that it favours managed services over self-hosted, and the cheapest option that still meets the stated requirement rather than the most capable one.
+- Inherits the distill ladder.
 
-## Exam Tips Mode
+---
 
-Triggered by: "exam tips", "gotchas", "traps", "what to watch out for"
-
-**Behavior:**
-- Pull from the exam tip sections at the end of each domain file
-- Organize by domain or topic as requested
-- Focus on the counter-intuitive facts that trip people up
-
-## Weak Spots / Focus Mode
+## Weak Spots Mode
 
 Triggered by: "weak spots", "what should I focus on", "high priority topics"
 
-**Behavior:**
-- **ACE:** Emphasize Domain 3 (25% weight -- biggest impact). Highlight: IAM least privilege, service selection, networking basics, Terraform
-- **PCA:** Emphasize Section 1 (25% weight -- biggest impact). Highlight: architecture trade-offs, DR/HA patterns, WAF pillars, case studies, VPC-SC, Vertex AI, Terraform modules
-- Suggest specific sections to re-read
-- Offer to quiz on those areas
+**Behaviour:**
+- Rank topics by `error rate x staleness x exam weight`, read from `progress.md`. Not by exam weight alone.
+- **If `progress.md` is empty or missing, say so plainly and offer the diagnostic instead of guessing.** A ranking with no performance data behind it is just the exam blueprint restated, and it will give the same answer on day 1 and day 50.
+- Name specific sections to re-read, and offer to quiz or teach-back on them.
+
+---
+
+## Accuracy note
+
+A full fact-check of the PCA material was run on 2026-08-09. Known-wrong content is tracked in `.claude/state/research/2026-08-09-pca-content-audit.md`. When answering from a doc section listed there as open, use the corrected fact from the audit and mention the discrepancy rather than repeating the error. When a fact looks doubtful and is not in the audit, verify against `cloud.google.com` before asserting it.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-# Quiz results are personal progress tracking - keep local only
+# Quiz results and progress tracking are personal performance data - keep local only
 gcp/ace/quizzes/
 gcp/pca/quizzes/
+gcp/ace/progress.md
+gcp/pca/progress.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,30 +89,40 @@ Multiple choice + multiple select (~50-60 questions, ~2 hours, ~70% to pass). In
 
 ## How to Assist
 
-The user will study by asking questions. Follow the interaction modes defined in `.claude/study-modes.md`. Default to **explain** mode unless the user asks to be quizzed or tested.
+The user will study by asking questions. Follow the interaction modes defined in `.claude/study-modes.md`. Default to **distill** mode unless the user asks to be quizzed or tested.
+
+**The active exam is PCA.** Read from `gcp/pca/`, quiz from `gcp/pca/questions/`, write to `gcp/pca/`. Only touch `gcp/ace/` when the user explicitly says ACE.
 
 ### Key rules
 
-1. **Always read the relevant study file(s) before answering** -- the materials are comprehensive and fact-checked. Base answers on them first, supplement with your own knowledge only when the files don't cover a topic.
-2. **Be concise** -- the user knows cloud well. Skip beginner-level explanations unless asked.
-3. **Include CLI commands** when relevant -- exams test CLI knowledge.
-4. **Flag exam traps** -- call out common wrong-answer patterns (e.g., "budgets don't stop spending", "Archive storage is NOT slow", "VPC peering is non-transitive").
-5. **Explain all options on quiz answers** -- after revealing the correct answer, explain WHY the correct answer is right AND WHY each wrong option is wrong. This reinforces learning by eliminating misconceptions about distractors.
-6. **Include an exam tip with every quiz answer** -- after explaining the options, add a short actionable exam tip (e.g., a keyword pattern, a decision shortcut, or a common trap) that helps the user quickly evaluate similar questions on the real exam.
-7. **Reference specific sections** -- point the user to the exact file and section for further reading.
-8. **Always link to official docs** -- every time you explain a service, command, concept, or feature, include a link to the relevant official Google Cloud documentation (e.g., `https://cloud.google.com/spanner/docs`). This applies to all interaction modes (explain, compare, decision, quiz explanations, etc.).
-9. **Use the domain reference** in `.claude/domain-reference.md` to quickly locate which file covers a topic.
-10. **Save quiz results** -- after each quiz session, save results to the appropriate exam's quizzes directory (`gcp/ace/quizzes/` or `gcp/pca/quizzes/`) as `{number}-{date}.md`. Check existing files to determine the next number.
+1. **Always read the relevant study file(s) before answering** -- base answers on them first, and supplement from your own knowledge only where the files are silent. Say when you are doing that.
+2. **Every conceptual answer uses the distill ladder** in `.claude/study-modes.md`: L0 through L3 always, L4 only on request. Never exceed the caps. Never write an explanatory paragraph outside L1 and L4.
+3. **Apply the deletion test before sending.** An L2 bullet survives only if removing it would change an answer the user would pick on the exam. If a topic seems to need a sixth bullet, it is two topics -- split it, never grow the list.
+4. **Only teach-back mode may set confidence 3** in `gcp/pca/progress.md`. Answering questions correctly can never set it. Recognising the right option and being able to explain it cold are different skills.
+5. **Require reasoning and a confidence tag before revealing a quiz answer.** A correct answer tagged `guess` is recorded as not known.
+6. **Explain all options on quiz answers** -- why the correct answer is right, and why each wrong option is wrong.
+7. **Include an exam tip with every quiz answer** -- a keyword pattern, a decision shortcut, or the trap the question was built on.
+8. **Flag exam traps** (e.g. "budgets don't stop spending", "Archive storage is NOT slow", "VPC peering is non-transitive"). These are L3 and belong in every explanation, not only when asked.
+9. **Always link to official docs** -- every service, command, concept or feature gets its `cloud.google.com` link, in every mode.
+10. **Reference specific sections** -- point to the exact file and section for further reading. Use `.claude/domain-reference.md` to locate the right file.
+11. **CLI commands are L4**, not L2. PCA tests which tool and why, not flag recall. Include commands when the user asks to expand, or when the command itself is the answer.
+12. **Check the errata before asserting a fact.** `.claude/state/research/2026-08-09-pca-content-audit.md` lists known-wrong content in the study guides. If a section is listed there as open, use the corrected fact and mention the discrepancy rather than repeating the error.
+13. **Save quiz results** to `gcp/pca/quizzes/{number}-{date}.md`, and update `gcp/pca/progress.md` in the same session. A session that does not write to the tracker did not happen.
 
 ## Quick Commands
 
 The user may use shorthand:
 
-- **"quiz me"** / **"test me"** -- switch to quiz mode (see study-modes.md)
+- **"explain [topic]"** / **"distill [topic]"** -- distilled explanation using the ladder
+- **"full picture"** / **"expand"** -- add L4 to the last answer (commands, limits, edge cases)
+- **"teach back [topic]"** / **"let me explain [topic]"** -- user explains from memory, Claude grades. The only way to reach confidence 3
+- **"dump [domain]"** -- teach-back across a whole domain
+- **"quiz me"** / **"test me"** / **"random question"** -- one question at a time, reasoning required before the answer
 - **"quiz me on [topic]"** -- quiz on a specific topic
-- **"explain [topic]"** -- give a focused explanation
+- **"mock exam"** -- 50 questions, 120 minutes, unseen only, no feedback until the end
+- **"drill [case study]"** -- constraint-by-constraint case study drill
+- **"review"** / **"what's due"** -- spaced review queue from progress.md
 - **"compare X vs Y"** -- comparison table with recommendations
 - **"when to use X?"** -- decision guidance with exam context
-- **"weak spots"** / **"what should I focus on?"** -- suggest high-value topics based on domain weights
-- **"random question"** -- pull a random question from practice questions
-- **"exam tips for [topic]"** -- exam-specific gotchas and traps
+- **"weak spots"** / **"what should I focus on?"** -- ranked by error rate, staleness and exam weight, from progress.md
+- **"exam tips for [topic]"** -- routes to distill mode; traps are L3 and appear in every explanation

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Study materials for cloud certification exams, designed to be used with [Claude 
 
 | Provider | Certification | Status | Guide |
 |----------|--------------|--------|-------|
-| GCP | Associate Cloud Engineer (Renewal) | Active | [gcp/ace/](./gcp/ace/) |
+| GCP | Professional Cloud Architect | **Active** | [gcp/pca/](./gcp/pca/) |
+| GCP | Associate Cloud Engineer (Renewal) | Reference | [gcp/ace/](./gcp/ace/) |
 
 ## How to Use This Repo
 

--- a/gcp/pca/README.md
+++ b/gcp/pca/README.md
@@ -4,16 +4,32 @@
 
 | Detail | Value |
 |--------|-------|
+| **Exam guide** | v6.1, effective 2025-10-30 |
 | **Duration** | 2 hours |
 | **Questions** | 50-60 (multiple choice + multiple select) |
+| **Case study questions** | **20-30% of the exam** (officially published) |
 | **Passing score** | ~70% (not officially published) |
 | **Cost** | $200 USD |
-| **Case studies** | 4 available, 2 appear on exam |
+| **Case studies** | 4 published, 2 appear on the exam |
 | **Recertification** | Every 2 years |
 
 **Registration:** [Google Cloud Certification](https://cloud.google.com/learn/certification/cloud-architect)
 
+### Renewal exam
+
+Different exam, different shape. If you are renewing rather than certifying for the first time:
+
+| Detail | Value |
+|--------|-------|
+| **Duration** | 1 hour |
+| **Questions** | 25 |
+| **Cost** | $100 USD |
+| **Case studies** | 1, aligned to generative AI |
+| **Case study questions** | 90-100% of the exam |
+
 ## Exam Sections & Weights
+
+> **Treat these weights as approximate.** They could not be independently confirmed on 2026-08-09: the [official exam guide PDF](https://services.google.com/fh/files/misc/professional_cloud_architect_exam_guide_english.pdf) renders its text as images, so the figures cannot be extracted or quoted directly. Third-party sources also disagree, with one variant reporting 25/18/19/15/11/12. The ordering is consistent across every source, so use these to rank effort, not to budget it to the percentage point. The one figure Google does publish prominently is that **case study questions are 20-30% of the exam**, which is why the study plan dedicates a full week to them.
 
 | # | Section | Weight | Study Guide |
 |---|---------|--------|-------------|
@@ -32,6 +48,16 @@
 | [08-case-studies.md](docs/08-case-studies.md) | 4 official case studies with analysis framework |
 | [09-decision-trees.md](docs/09-decision-trees.md) | Architect-level service selection decision trees |
 | [10-key-commands-and-terraform.md](docs/10-key-commands-and-terraform.md) | gcloud at architect level, Terraform deep dive, kubectl |
+
+## Studying
+
+| File | Purpose |
+|------|---------|
+| [study-plan.md](study-plan.md) | 8-week plan working backward from the exam date, with a go/no-go gate |
+| `progress.md` | Per-topic confidence and review schedule (gitignored, created on first use) |
+| [.claude/study-modes.md](../../.claude/study-modes.md) | How Claude behaves in each mode: distill, quiz, teach-back, case drill, mock exam, review |
+
+Start with `mock exam` only after the diagnostic. Start with "quiz me" to build the tracker, and "teach back X" to prove you can explain a topic cold, which is the only thing that sets confidence 3.
 
 ## Practice Questions (~260 total)
 

--- a/gcp/pca/docs/08-case-studies.md
+++ b/gcp/pca/docs/08-case-studies.md
@@ -24,7 +24,7 @@
 
 ## Case Study 1: EHR Healthcare
 
-**Official doc:** [EHR Healthcare Case Study](https://services.google.com/fh/files/blogs/master_case_study_ehr_healthcare.pdf)
+**Official doc:** [EHR Healthcare Case Study](https://services.google.com/fh/files/misc/v6.1_pca_ehr_healthcare_case_study_english.pdf)
 
 ### Company Overview
 
@@ -280,7 +280,7 @@ Phase 4: Analytics & Optimization (Months 5-7)
 
 ## Case Study 2: Cymbal Retail
 
-**Official doc:** [Cymbal Retail Case Study](https://services.google.com/fh/files/blogs/master_case_study_cymbal_retail.pdf)
+**Official doc:** [Cymbal Retail Case Study](https://services.google.com/fh/files/misc/v6.1_pca_cymbal_retail_case_study_english.pdf)
 
 ### Company Overview
 
@@ -567,7 +567,7 @@ Strangler Fig Pattern:
 
 ## Case Study 3: Altostrat Media
 
-**Official doc:** [Altostrat Media Case Study](https://services.google.com/fh/files/blogs/master_case_study_altostrat_media.pdf)
+**Official doc:** [Altostrat Media Case Study](https://services.google.com/fh/files/misc/v6.1_pca_altostrat_media_case_study_english.pdf)
 
 ### Company Overview
 
@@ -894,7 +894,7 @@ Key considerations:
 
 ## Case Study 4: KnightMotives Automotive
 
-**Official doc:** [KnightMotives Automotive Case Study](https://services.google.com/fh/files/blogs/master_case_study_knightmotives_automotive.pdf)
+**Official doc:** [KnightMotives Automotive Case Study](https://services.google.com/fh/files/misc/v6.1_pca_knightmotives_automotive_case_study_english.pdf)
 
 ### Company Overview
 

--- a/gcp/pca/questions/case-study-questions.md
+++ b/gcp/pca/questions/case-study-questions.md
@@ -74,16 +74,16 @@ B) Set up a single Partner Interconnect connection with 10 Gbps capacity and con
 
 C) Deploy redundant HA VPN gateways with multiple tunnels across two regions. Use BGP for dynamic routing and rely on IPsec encryption provided by the VPN tunnels.
 
-D) Provision two Dedicated Interconnect connections in different metro areas (edge availability domains) for 99.99% SLA. Add a Cloud HA VPN overlay on top of the Interconnect for encrypted transit and as a failover path.
+D) Provision four Dedicated Interconnect connections, two in each of two metro areas, with the two in each metro landing in different edge availability domains, for a 99.99% SLA. Add a Cloud HA VPN overlay on top of the Interconnect for encrypted transit and as a failover path.
 
 <details>
 <summary>Answer</summary>
 
 **Correct: D)**
 
-This design addresses all three requirements. Two Dedicated Interconnect connections in different edge availability domains provide the highest availability (up to 99.99% SLA, exceeding the 99.9% requirement). At 5 Gbps consistent throughput, Dedicated Interconnect (minimum 10 Gbps per connection) easily handles the load. The HA VPN overlay running over the Interconnect connections provides IPsec encryption for data in transit, meeting HIPAA requirements. The VPN also serves as an encrypted failover path.
+This design addresses all three requirements. The 99.99% SLA has a specific topology: **four** connections, two per metro across two metros, with the pair in each metro landing in separate edge availability domains. Anything less tops out at 99.9%. At 5 Gbps consistent throughput, Dedicated Interconnect (10 Gbps minimum per connection) carries the load easily. The HA VPN overlay running over the Interconnect provides IPsec encryption in transit and doubles as an encrypted failover path.
 
-- **A is wrong:** Two Interconnect connections in the same metro only achieves 99.9% SLA (not leveraging different edge availability domains for maximum resilience). More critically, application-layer TLS alone may not satisfy HIPAA data-in-transit requirements at the network level -- a VPN overlay or MACsec provides more comprehensive encryption.
+- **A is wrong:** Two connections in a single metro is the 99.9% topology, not 99.99%, and it leaves the whole metro as a failure domain. More critically, application-layer TLS alone may not satisfy the data-in-transit requirement at the network level -- a VPN overlay or MACsec is the stronger answer.
 - **B is wrong:** A single Partner Interconnect is a single point of failure and does not meet the 99.9% SLA on its own. MACsec availability depends on the partner/location and is not guaranteed.
 - **C is wrong:** HA VPN maxes out at ~3 Gbps per tunnel. While multiple tunnels can aggregate throughput, achieving consistent 5 Gbps with headroom requires many tunnels and is operationally complex. Dedicated Interconnect is the right choice for this throughput level.
 

--- a/gcp/pca/study-plan.md
+++ b/gcp/pca/study-plan.md
@@ -1,0 +1,105 @@
+# PCA Study Plan
+
+**Exam date: not booked.** Book it before starting. A plan without a date produces no sequencing and no urgency, and every week without one is a week the schedule below cannot be anchored to.
+
+Suggested target: **2026-10-04**, which gives the full 8 weeks from 2026-08-09. Register at [Google Cloud Certification](https://cloud.google.com/learn/certification/cloud-architect).
+
+Once booked, replace `D` below with the real date and fill the header of `gcp/pca/progress.md`.
+
+---
+
+## Assumptions
+
+- Around 4-6 hours per week, alongside full-time work.
+- Two weekday evenings of 45 minutes, one weekend block of 2 hours.
+- You already work with GCP daily, so this plan is weighted toward retrieval practice and architectural judgment, not toward learning services from scratch.
+
+## Session shape
+
+Every session, without exception:
+
+- One topic. 45 minutes maximum.
+- Ends with a teach-back.
+- Ends with a write to `gcp/pca/progress.md`.
+
+A session that does not write to the tracker did not happen. The tracker is what makes weak-spot ranking, spaced review, and mock-exam hygiene work; skipping the write silently breaks all three.
+
+---
+
+## The schedule
+
+### D-56, week 1: baseline
+
+You cannot plan around performance you have not measured. This week exists to produce data, not to learn.
+
+- 30-question untimed diagnostic, spread across all six sections. Reasoning required on every answer, with a `sure` / `think so` / `guess` tag.
+- Seed `progress.md` from the results.
+- Distill passes on the three weakest domains that come out of it.
+
+Expect the diagnostic to feel bad. That is the point: it is measuring, not teaching.
+
+### D-49 to D-15, weeks 2 to 5: domain cycles
+
+One to two domains per week, heaviest first. Section 1 (designing and planning) is the largest single block, so it goes first.
+
+- **Evening A (45 min):** distill 3-4 topics, teach-back each one.
+- **Evening B (45 min):** 20-question quiz on the week's domain.
+- **Weekend (2 h):** 40-question mixed quiz, plus the review queue, plus a tracker update.
+
+Suggested order, heaviest and most architectural first:
+
+1. Week 2: designing and planning (section 1)
+2. Week 3: security and compliance (section 3), provisioning infrastructure (section 2)
+3. Week 4: optimizing processes (section 4), managing implementations (section 5)
+4. Week 5: operations excellence (section 6), plus the Well-Architected Framework as a cross-cutting pass
+
+### D-14, week 6: case studies
+
+Case study questions are 20-30% of the exam, which makes this the highest-value week in the plan.
+
+- One case drill per case study, 45 minutes each. Four cases, four sessions.
+- The 20 case study questions in the bank.
+- Re-read `docs/08-case-studies.md` for the two cases you found hardest.
+
+Before this week starts, confirm the four published case studies are still current on the [certification page](https://cloud.google.com/learn/certification/cloud-architect). Google rotates them, and drilling a retired case is wasted time.
+
+### D-13, week 7: mock exam 1 and repair
+
+- **Mock exam 1**: 50 questions, 120 minutes, unseen questions only, no feedback until the end.
+- The rest of the week is repair. Every miss becomes a distill pass and a teach-back.
+
+### D-6, week 8: mock exam 2 and repair
+
+- **Mock exam 2**, same conditions.
+- Repair the misses.
+
+### D-2 and D-1
+
+- D-2: review queue plus L0 and L2 cards only. No new material. Adding material this late displaces consolidation and does not stick.
+- D-1: rest.
+
+---
+
+## Go/no-go gate
+
+- Mock 1 at **75% or better**
+- Mock 2 at **80% or better**
+
+Below 80% at D-6, move the date.
+
+The pass mark is around 70%, so these targets carry deliberate headroom. A self-administered mock drawn from a bank you have been studying runs easier than the real exam: the phrasing is familiar, there is no time pressure from an unfamiliar interface, and the questions were written by the same process that wrote your study notes. Treat a 75% mock as roughly a coin flip on the day.
+
+---
+
+## What this plan deliberately does not include
+
+- **More practice questions up front.** 260 is more than enough for 8 weeks, and every question consumed in practice is one that cannot appear in a mock. Generate new ones only for weak topics.
+- **A third and fourth mock.** Two plus the diagnostic is enough, and mocks eat the unseen-question budget that makes them valid.
+- **Re-reading the study guides end to end.** 15,000 lines cannot be re-read in the final week, and re-reading is the weakest form of study for a scenario exam. Retrieval practice beats review.
+- **Invented case studies.** Only the four official ones match the exam's phrasing.
+
+---
+
+## Known content issues
+
+A full fact-check ran on 2026-08-09 and found errors in the study guides, tracked in `.claude/state/research/2026-08-09-pca-content-audit.md`. The wrong answer keys are fixed. Doc-level errata is still open, so when a fact looks doubtful, check it against `cloud.google.com` rather than trusting the guide.


### PR DESCRIPTION
## Summary

- The repo had content and a quiz mode but **no way to measure progress**. `gcp/pca/quizzes/` had never been created, so the weak-area weighting in `study-modes.md` had never had any data to run on.
- This adds the measurement and scheduling layers, and turns "distil until it cannot be distilled" into a format with checkable limits rather than a request Claude drifts away from.

## The distillation format

Placed first in `.claude/study-modes.md` so every mode inherits it. `CLAUDE.md` rule 2 changes from "be concise" to a reference to this ladder.

| Rung | Content | Cap |
|---|---|---|
| L0 | What it is, and the one problem it solves | 20 words |
| L1 | Why it exists: what breaks without it | 2 sentences |
| L2 | The decision-relevant facts | 5 bullets, 12 words each |
| L3 | The trap: how the exam makes you pick wrong | 4 bullets |
| L4 | Commands, limits, edge cases | on request only |

Two rules stop it drifting back into prose:

- **Deletion test.** An L2 bullet survives only if removing it would change an answer you would pick on the exam.
- **No overflow.** A sixth L2 bullet means it is two topics. Split it, never grow the list.

"Be concise" failed because it has no stop condition. "20 words" and "5 bullets" can be checked against a draft.

## Measurement

`gcp/pca/progress.md`, gitignored as personal performance data alongside `quizzes/`. Per-topic confidence 0-3, seen / right / **guessed right** counts, next review date, plus a mock log.

Two rules carry the weight here:

- **Only teach-back mode can set confidence 3.** Answering questions correctly never does. Recognising the right option and generating the explanation cold are different skills, and only the second one survives the exam room. This is what makes "I can explain it in plain words" measurable.
- **Quiz mode requires reasoning plus a `sure` / `think so` / `guess` tag before the answer is revealed.** A correct answer tagged `guess` records as *not known*. On a 70% exam, lucky guesses are exactly the margin, and recording them as mastery hides the gap.

## New modes

- **Teach-back** -- Claude names the topic and says nothing else. You explain from memory. It returns three lists: covered, missed, stated wrong. No praise, no re-teaching.
- **Case drill** -- constraints fed one at a time, "what does this rule out and what does it force", ending in a six-line architecture. Case study questions are 20-30% of the exam and nothing exercised this.
- **Mock exam** -- 50 questions, 120 minutes, previously unseen only, no feedback until the end. Immediate feedback is good for learning and useless for calibration.
- **Review** -- spaced queue on three fixed intervals (2 / 7 / 21 days, reset on any wrong answer or `guess`). No SM-2, no ease factors.

**Exam tips mode is cut**, folded into L3 so traps appear in every explanation rather than only when asked. **Weak spots** is now ranked by error rate, staleness and weight from `progress.md`, and says so plainly when there is no data instead of restating the exam blueprint.

## Also fixed

- **Three dead case study links.** Cymbal, Altostrat and KnightMotives all returned 404; only EHR resolved. All four now point at the `v6.1_pca_*` URLs, each verified 200.
- **A wrong SLA topology** in `case-study-questions.md`: a 99.99% Interconnect SLA was claimed from two connections across two metros. It needs four, two per metro in separate edge availability domains, which the repo already stated correctly in `docs/09:310`.
- **README**: PCA is now the active exam, the published 20-30% case study share is recorded, and the renewal exam is documented (1 hour, 25 questions, and 90-100% case study based, which is a very different exam).

## One thing to read before trusting the weights

The section weight table now carries a caveat. Two auditors flatly contradicted each other on whether Google publishes per-section weights, and **neither claim is reproducible**: the official exam guide renders its text as images, so nothing can be quoted from it. A third-party variant reports 25/18/19/15/11/12 instead. The numbers are kept, since the ordering is consistent everywhere, with a note that they are approximate.

## Open, and deliberately not actioned

The audit also claimed `docs/08-case-studies.md` is largely fabricated. That is recorded in the errata as **unverified**, with the reasoning: the evidence offered was text extraction from those PDFs, which is not possible, and a fetch of one PDF then asserted the opposite. It needs someone to open the four PDFs by hand before anything is rewritten.