### PR TITLE
fix(pca): remove fabricated gcloud commands and reconcile cost figures

### DIFF
--- a/.claude/state/research/2026-08-09-pca-content-audit.md
+++ b/.claude/state/research/2026-08-09-pca-content-audit.md
@@ -72,27 +72,27 @@ Marked answer survives; the reasoning does not.
 
 A learner who types these gets "unrecognized". Highest-confusion class of error.
 
-- [ ] `docs/02:1724`, `02:1731` - `gcloud ai pipelines run create` / `schedules create`. No `pipelines` group under `gcloud ai`. Pipelines are SDK/REST only.
-- [ ] `docs/02:1933` - `gcloud ai batch-prediction-jobs create`. No such group.
+- [x] `docs/02:1724`, `02:1731` - `gcloud ai pipelines run create` / `schedules create`. No `pipelines` group under `gcloud ai`. Pipelines are SDK/REST only.
+- [x] `docs/02:1933` - `gcloud ai batch-prediction-jobs create`. No such group.
 - [ ] `docs/02:1793`, `02:1799` - `gcloud ai feature-online-stores` / `feature-views` exist only under `gcloud beta ai`.
-- [ ] `docs/03:769-777` - `gcloud dlp inspect-content` / `deidentify-content`. Actual surface is `gcloud alpha dlp text inspect` / `redact`.
-- [ ] `docs/03:611-614` and `04:385-387` - `--enable-vulnerability-scanning`. Real flag is `--allow-vulnerability-scanning`.
-- [ ] `docs/04:77-84` and `06:1350-1363` and `07:145` - `gcloud monitoring slos create/list/describe`. No `slos` group. SLOs come from the Monitoring API v3, Terraform `google_monitoring_slo`, or the console. Significant because 6.5 is the SLO objective.
+- [x] `docs/03:769-777` - `gcloud dlp inspect-content` / `deidentify-content`. Actual surface is `gcloud alpha dlp text inspect` / `redact`.
+- [x] `docs/03:611-614` and `04:385-387` - `--enable-vulnerability-scanning`. Real flag is `--allow-vulnerability-scanning`.
+- [x] `docs/04:77-84` and `06:1350-1363` and `07:145` - `gcloud monitoring slos create/list/describe`. No `slos` group. SLOs come from the Monitoring API v3, Terraform `google_monitoring_slo`, or the console. Significant because 6.5 is the SLO objective.
 - [ ] `docs/04:713-717` - `gcloud logging metrics create --bucket-options=...`. No such flag; distribution metrics need `--config-from-file`.
-- [ ] `docs/04:889-898` - `gcloud privatecatalog catalogs create` / `products create`. Not real; the surface is search-only. Product also renamed to Service Catalog in 2022.
+- [x] `docs/04:889-898` - `gcloud privatecatalog catalogs create` / `products create`. Not real; the surface is search-only. Product also renamed to Service Catalog in 2022.
 - [ ] `docs/04:1352-1357` - `gcloud monitoring policies create --condition-display-name/--condition-filter/--condition-threshold-value`. Invented flags; takes `--policy` / `--policy-from-file`.
-- [ ] `docs/06:76`, `06:80-85` - `gcloud monitoring metrics-descriptors list/create`. No such group on any track. GA groups are dashboards, policies, snoozes, uptime.
-- [ ] `docs/06:234`, `06:237-240`, `07:139-142` - `gcloud monitoring channels`. Beta only.
-- [ ] `docs/06:634` - `gcloud beta error-events list`. Correct group is `gcloud beta error-reporting events list`.
-- [ ] `docs/07:1293` - `gcloud beta carbon-footprint get`. No such group; use the BigQuery export.
-- [ ] `docs/10:184-186` - `gcloud ai pipelines runs create`. Fabricated.
+- [x] `docs/06:76`, `06:80-85` - `gcloud monitoring metrics-descriptors list/create`. No such group on any track. GA groups are dashboards, policies, snoozes, uptime.
+- [x] `docs/06:234`, `06:237-240`, `07:139-142` - `gcloud monitoring channels`. Beta only.
+- [x] `docs/06:634` - `gcloud beta error-events list`. Correct group is `gcloud beta error-reporting events list`.
+- [x] `docs/07:1293` - `gcloud beta carbon-footprint get`. No such group; use the BigQuery export.
+- [x] `docs/10:184-186` - `gcloud ai pipelines runs create`. Fabricated.
 - [ ] `docs/05:2040` - `gcloud services quota update` is alpha-only.
-- [ ] `docs/07:831` - org policy `constraints/compute.requireLabels` does not exist. Label governance uses tags or apply-time policy-as-code.
-- [ ] `docs/07:361` - `enable-enforce` used on `compute.vmExternalIpAccess`, which is a list constraint needing `set-policy`. The three neighbouring boolean constraints are correct, which makes this harder to spot.
+- [x] `docs/07:831` - org policy `constraints/compute.requireLabels` does not exist. Label governance uses tags or apply-time policy-as-code.
+- [x] `docs/07:361` - `enable-enforce` used on `compute.vmExternalIpAccess`, which is a list constraint needing `set-policy`. The three neighbouring boolean constraints are correct, which makes this harder to spot.
 
 ## P1 - numbers that are wrong
 
-- [ ] `docs/07:1026` - Hyperdisk "up to 2.4 TB/s". Off by 1000x. Hyperdisk Balanced maxes at 2,400 MiB/s per volume; Extreme at 5,000 MiB/s; only Hyperdisk ML reaches ~2 TiB/s.
+- [x] `docs/07:1026` - Hyperdisk "up to 2.4 TB/s". Off by 1000x. Hyperdisk Balanced maxes at 2,400 MiB/s per volume; Extreme at 5,000 MiB/s; only Hyperdisk ML reaches ~2 TiB/s.
 - [ ] `docs/06:68` - metric retention "5 years". Actual 24 months (6 weeks native, then 10-minute).
 - [ ] `docs/06:72` - log-based metrics "24 months". Actual 6 weeks.
 - [ ] `docs/06:1226` - Enhanced support minimum "$500/month" (actual $100); Premium "contact sales" (published minimum $15,000/month).
@@ -102,10 +102,10 @@ A learner who types these gets "unrecognized". Highest-confusion class of error.
 - [ ] `docs/01:576` - Spanner "1 node ~ 10,000 reads/sec or 2,000 writes/sec". Current: 22,500 peak reads/sec, 3,500 peak writes/sec (22,500 with throughput-optimized writes).
 - [ ] `docs/02:873` - Bigtable "10K rows/sec reads and writes". Current SSD node: up to 17,000 reads/sec, 14,000 writes/sec.
 - [ ] `docs/07:624` - `nam14` replica list wrong. Actual: read-write in us-east4 (default leader) and northamerica-northeast1, witness in us-east1.
-- [ ] `docs/07:749`, `07:760` - CUD "20-57%" / "~57% memory-optimized". Actual up to 55% for most series, up to 70% memory-optimized. Flexible CUDs (17-63%) missing entirely.
-- [ ] `docs/04:1457-1462` - SUD tier table (~8.3% / ~16.7% / 30%). Published tiers are 0 / 10 / 20 / 30% across quartiles.
-- [ ] `docs/04:1453` - "SUDs do not apply to sole-tenant nodes". They do, including the sole-tenancy premium.
-- [ ] `docs/01:126-127` - claims C2 is SUD-ineligible. C2 is eligible (20% max), as are M1 and M2 (30%). The flat "up to 30%" is wrong for N2/N2D/C2.
+- [x] `docs/07:749`, `07:760` - CUD "20-57%" / "~57% memory-optimized". Actual up to 55% for most series, up to 70% memory-optimized. Flexible CUDs (17-63%) missing entirely.
+- [x] `docs/04:1457-1462` - SUD tier table (~8.3% / ~16.7% / 30%). Published tiers are 0 / 10 / 20 / 30% across quartiles.
+- [x] `docs/04:1453` - "SUDs do not apply to sole-tenant nodes". They do, including the sole-tenancy premium.
+- [x] `docs/01:126-127` - claims C2 is SUD-ineligible. C2 is eligible (20% max), as are M1 and M2 (30%). The flat "up to 30%" is wrong for N2/N2D/C2.
 - [ ] `docs/02:997` - Firestore PITR "enabled by default, 1-hour granularity". Both wrong: disabled by default, 1-minute granularity. Contradicts `01:674` which is correct.
 - [ ] `docs/02:900` - BigQuery Standard edition shown with 1yr/3yr commitments. Standard has no capacity commitments.
 - [ ] `docs/02:1577` - Cloud Run "max timeout 60 min (default)". Default is 5 minutes; 60 is the max.
@@ -119,7 +119,7 @@ A learner who types these gets "unrecognized". Highest-confusion class of error.
 - [ ] `docs/09:305`, `09:309`, `09:367` - Dedicated Interconnect "10-200 Gbps". Now 10, 100 and 400 Gbps link types.
 - [ ] `docs/09:322`, `09:329`, `09:369` and `02:22` - HA VPN "3 Gbps per tunnel". Documented limit is 250,000 packets/sec, which is 1-3 Gbps depending on packet size.
 - [ ] `docs/07:858-862` - inter-region egress "$0.01/GB". Within North America it is $0.02/GB.
-- [ ] `docs/07:711` and `02:596` conflict on storage class SLAs. `02:596` is correct (99.9% multi/dual-region, 99.0% regional for the cold classes). `07:711` flattens all three to 99.0% and is wrong.
+- [x] `docs/07:711` and `02:596` conflict on storage class SLAs. `02:596` is correct (99.9% multi/dual-region, 99.0% regional for the cold classes). `07:711` flattens all three to 99.0% and is wrong.
 - [ ] `docs/01:727` - Dedicated Interconnect "99.9% (1 link)". A single link carries no SLA.
 - [ ] `docs/06:1371` vs `06:668`/`06:1388-1391` - two different downtime bases (43.8 vs 43.2 min). Pick the 30-day basis and make it consistent.
 
@@ -132,7 +132,7 @@ A learner who types these gets "unrecognized". Highest-confusion class of error.
 - [ ] `docs/04:668` - "Cloud Deploy canary requires a service mesh". It supports plain Kubernetes service networking.
 - [ ] `docs/04:693` - Cloud Debugger "replaced by Snapshot Debugger". Both are gone; delete the row.
 - [ ] `docs/04:1015` - "Memorystore Redis cross-region replication, Standard tier". Standard tier is cross-zone within one region. Cross-region is a Redis Cluster / Valkey feature.
-- [ ] `docs/04:1414` - resource-based CUDs cover Dataflow. They do not.
+- [x] `docs/04:1414` - resource-based CUDs cover Dataflow. They do not.
 - [ ] `docs/04:1291` - "AlloyDB single-region only". AlloyDB supports cross-region replication.
 - [ ] `docs/03:226-227` - "Key Access Justifications only available with EKM". KAJ works on software and HSM keys too.
 - [ ] `docs/03:583`, `03:641` - "Binary Authorization is for GKE". Also Cloud Run, Cloud Service Mesh, Google Distributed Cloud. Contradicts `04:397`.

--- a/gcp/pca/docs/01-designing-planning-architecture.md
+++ b/gcp/pca/docs/01-designing-planning-architecture.md
@@ -99,13 +99,17 @@ Architects must translate business goals into technical architecture. The exam t
 
 ### Cost Optimization
 
-**Committed Use Discounts (CUDs):**
-- 1-year or 3-year commitments for predictable workloads
-- **Resource-based CUDs**: Commit to specific vCPU/memory amounts (Compute Engine, GKE)
-  - 1-year: ~37% discount, 3-year: ~55% discount
-- **Spend-based CUDs**: Commit to $/hour spend (Cloud SQL, AlloyDB, Cloud Run, BigQuery editions)
-  - 1-year: ~25% discount, 3-year: ~52% discount
+**Committed Use Discounts (CUDs):** three kinds, and knowing which is which is the exam skill.
+
+| Type | Commit to | Locked to | 1-year | 3-year |
+|------|-----------|-----------|--------|--------|
+| **Resource-based** | Specific vCPU and memory in one region | Region and machine family | ~37% | up to 55% (up to 70% memory-optimized) |
+| **Flexible (spend-based compute)** | $/hour of compute spend | Nothing: portable across region and machine family | ~28% | ~46% |
+| **Spend-based (service)** | $/hour on a specific service (Cloud SQL, AlloyDB, Cloud Run, BigQuery editions) | That service | ~25% | ~52% |
+
 - CUDs apply automatically across projects in the same billing account
+- **Flexible CUDs are the current default recommendation** for compute where the workload may move between regions or machine families. You trade a lower discount rate for not being locked to a family or region, and they cover Cloud Run and GKE Autopilot as well as Compute Engine
+- Resource-based still wins on rate when the shape of the workload is genuinely stable
 
 ```bash
 # List active commitments
@@ -121,11 +125,11 @@ gcloud compute commitments create my-commitment \
 ```
 
 **Sustained Use Discounts (SUDs):**
-- Automatic discounts for running resources 25%+ of a month
-- Up to ~30% discount at full-month usage
-- Apply to N1, N2, N2D machine types and sole-tenant nodes
-- **Do NOT apply to:** E2, T2D, Tau, C2, C2D, A2, Spot VMs, or committed-use resources
-- Applied automatically per billing account per region
+- Automatic, no commitment, applied per billing account per region
+- Earned in quarters of the month: 0% for the first quarter, then 10%, 20%, 30% as usage accumulates
+- **The maximum depends on the family:** up to **30%** for N1, M1 and M2; up to **20%** for N2, N2D and C2
+- **Do apply to sole-tenant nodes**, including the sole-tenancy premium
+- **Do NOT apply to:** E2, Spot VMs, or resources already covered by a commitment
 
 **Other cost levers:**
 

--- a/gcp/pca/docs/02-managing-provisioning-infrastructure.md
+++ b/gcp/pca/docs/02-managing-provisioning-infrastructure.md
@@ -1253,9 +1253,10 @@ gcloud compute instance-groups managed create spot-mig \
 | Strategy | Discount | Commitment | Flexibility |
 |----------|---------|------------|-------------|
 | **Spot VMs** | 60-91% | None (can be preempted) | Highest |
-| **3-year CUD** | Up to 57% | 3 years | Lowest |
-| **1-year CUD** | Up to 37% | 1 year | Low |
-| **Sustained use discount (SUD)** | Up to 30% | None (automatic) | High |
+| **3-year resource CUD** | Up to 55% (70% memory-optimized) | 3 years | Lowest |
+| **1-year resource CUD** | Up to 37% | 1 year | Low |
+| **Flexible CUD** | ~46% (3yr), ~28% (1yr) | 1 or 3 years | Medium: portable across region and family |
+| **Sustained use discount (SUD)** | Up to 30% (N1/M1/M2), 20% (N2/N2D/C2) | None (automatic) | High |
 | **On-demand** | 0% | None | Highest |
 
 **Exam tips:**
@@ -1720,19 +1721,19 @@ Model training -> Model evaluation -> Model deployment (conditional)
 ```
 
 ```bash
-# Submit a pipeline run
-gcloud ai pipelines run create \
-  --display-name=my-training-pipeline \
-  --template-path=gs://my-bucket/pipeline.yaml \
-  --region=us-central1 \
-  --parameter-values='{"learning_rate": 0.01, "epochs": 100}'
-
-# Schedule a pipeline
-gcloud ai pipelines schedules create \
-  --display-name=weekly-retrain \
-  --template-path=gs://my-bucket/pipeline.yaml \
-  --region=us-central1 \
-  --cron="0 2 * * 0"
+# There is no `pipelines` group under `gcloud ai`. Pipelines have no gcloud
+# surface at all: they are submitted from the Python SDK, the REST API, or the
+# console. For the exam, know that pipelines are defined as code and scheduled,
+# not that a CLI flag exists.
+#
+#   from google.cloud import aiplatform
+#   job = aiplatform.PipelineJob(
+#       display_name="my-training-pipeline",
+#       template_path="gs://my-bucket/pipeline.yaml",
+#       parameter_values={"learning_rate": 0.01, "epochs": 100},
+#   )
+#   job.submit()                      # one-off run
+#   job.create_schedule(cron="0 2 * * 0")   # recurring retrain
 ```
 
 **Python SDK example (conceptual -- know the pattern for the exam):**
@@ -1929,13 +1930,15 @@ gcloud ai endpoints deploy-model my-endpoint \
   --max-replica-count=5 \
   --region=us-central1
 
-# Run batch prediction
-gcloud ai batch-prediction-jobs create \
-  --model=my-model \
-  --input-path=gs://my-bucket/input/ \
-  --output-path=gs://my-bucket/output/ \
-  --region=us-central1 \
-  --machine-type=n1-standard-4
+# There is no `batch-prediction-jobs` group under `gcloud ai` either.
+# Batch prediction runs from the SDK, REST, or the console:
+#
+#   model.batch_predict(
+#       job_display_name="nightly-scoring",
+#       gcs_source="gs://my-bucket/input/",
+#       gcs_destination_prefix="gs://my-bucket/output/",
+#       machine_type="n1-standard-4",
+#   )
 ```
 
 #### Model Optimization Techniques

--- a/gcp/pca/docs/03-security-and-compliance.md
+++ b/gcp/pca/docs/03-security-and-compliance.md
@@ -611,7 +611,7 @@ gcloud artifacts repositories create my-repo \
 # Enable vulnerability scanning
 gcloud artifacts repositories update my-repo \
   --location=us-central1 \
-  --enable-vulnerability-scanning
+  --allow-vulnerability-scanning
 
 # Scan an image
 gcloud artifacts docker images scan us-central1-docker.pkg.dev/my-project/my-repo/my-image:latest
@@ -766,15 +766,14 @@ gcloud resource-manager org-policies set-policy location-policy.yaml --organizat
 - Apply column-level security in BigQuery for PII columns
 
 ```bash
-# Inspect content for PII
-gcloud dlp inspect-content --content="My SSN is 123-45-6789" \
+# The gcloud surface is alpha and differently named. At architect level the
+# point is that inspection and de-identification are API operations you wire
+# into a pipeline, not a CLI habit.
+gcloud alpha dlp text inspect --content="My SSN is 123-45-6789" \
   --info-types=US_SOCIAL_SECURITY_NUMBER
 
-# De-identify (mask SSN)
-gcloud dlp deidentify-content \
-  --content="My SSN is 123-45-6789" \
-  --info-types=US_SOCIAL_SECURITY_NUMBER \
-  --deidentify-config=mask-config.json
+gcloud alpha dlp text redact --content="My SSN is 123-45-6789" \
+  --info-types=US_SOCIAL_SECURITY_NUMBER
 ```
 
 **Data Retention Requirements:**

--- a/gcp/pca/docs/04-optimizing-processes.md
+++ b/gcp/pca/docs/04-optimizing-processes.md
@@ -73,14 +73,15 @@ The exam tests whether you understand SRE principles and can map them to GCP ser
 - **Toil Reduction:** Automate repetitive operational work. Use Cloud Functions, Cloud Scheduler, Workflows for automation.
 
 ```bash
-# Create an SLO in Cloud Monitoring (typically done via Terraform or Console, but CLI exists)
-gcloud monitoring slos create \
-  --service=my-service \
-  --display-name="Availability SLO" \
-  --goal=0.999 \
-  --rolling-period=30d \
-  --request-based-sli \
-  --good-total-ratio-filter='metric.type="monitoring.googleapis.com/uptime_check/request_count" resource.type="uptime_url"'
+# SLOs have no gcloud surface. They are created via the Monitoring API v3,
+# Terraform, or the console. Terraform is the form worth knowing.
+#
+#   resource "google_monitoring_slo" "availability" {
+#     service             = google_monitoring_custom_service.api.service_id
+#     goal                = 0.999
+#     rolling_period_days = 30
+#     request_based_sli { good_total_ratio { ... } }
+#   }
 ```
 
 **Exam tips:**
@@ -384,7 +385,7 @@ Artifact Registry integrates with Artifact Analysis (formerly Container Analysis
 # Enable on-push scanning
 gcloud artifacts repositories update my-repo \
   --location=us-central1 \
-  --enable-vulnerability-scanning
+  --allow-vulnerability-scanning
 
 # View scan results
 gcloud artifacts docker images list us-central1-docker.pkg.dev/my-project/my-repo \
@@ -886,16 +887,12 @@ Private Catalog allows platform teams to publish Terraform modules, Deployment M
 - **Version:** Each solution can have multiple versions for controlled rollouts.
 
 ```bash
-# Create a catalog
-gcloud privatecatalog catalogs create my-catalog \
-  --display-name="Platform Solutions" \
-  --organization=123456789
+# The gcloud `privatecatalog` surface is search-only. Catalogs and solutions are
+# created in the console or through the Service Catalog API. The product was
+# renamed from Private Catalog to Service Catalog in 2022.
 
-# Add a solution (Terraform module)
-gcloud privatecatalog products create web-app-template \
-  --catalog=my-catalog \
-  --display-name="Standard Web Application" \
-  --asset-type=terraform
+# Search the catalogs available to you
+gcloud privatecatalog products search --query="web application"
 ```
 
 **Terraform Modules as Service Catalog Entries:**
@@ -1405,22 +1402,25 @@ FinOps (Financial Operations) is the practice of bringing financial accountabili
 
 #### Committed Use Discounts (CUDs)
 
-CUDs provide significant discounts (up to 57% for compute, up to 70% for memory-optimized) in exchange for a 1-year or 3-year commitment.
+CUDs give a discount in exchange for a 1-year or 3-year commitment. There are **three** types, and the exam tests which one fits a described workload.
 
-**Two Types of CUDs:**
+| Type | What You Commit To | Flexibility | 1-year | 3-year |
+|------|-------------------|-------------|--------|--------|
+| **Resource-based CUDs** | Specific vCPU count and memory in one region | Locked to that region and machine family. Covers Compute Engine and GKE nodes | ~37% | up to 55% (up to 70% memory-optimized) |
+| **Flexible CUDs** (spend-based compute) | Dollar amount per hour of compute spend | Portable across regions and machine families. Covers Compute Engine, GKE Autopilot and Cloud Run | ~28% | ~46% |
+| **Spend-based CUDs** (per service) | Dollar amount per hour on one service | Cloud SQL, AlloyDB, VMware Engine, BigQuery editions and other eligible services | ~25% | ~52% |
 
-| Type | What You Commit To | Flexibility | Discount |
-|------|-------------------|-------------|----------|
-| **Resource-based CUDs** | Specific vCPU count and memory amount in a region | Applies to any VM type using those resources (GCE, GKE nodes, Dataflow) | Up to 57% (3-year) |
-| **Spend-based CUDs** | Dollar amount per hour on specific services | Applies to Cloud SQL, VMware Engine, Cloud Run, and other eligible services | Up to 52% (3-year) |
+**Flexible CUDs are what Google leads with now.** You accept a lower rate in return for not being locked to a machine family or region, which suits any workload that might be re-shaped or moved. Reach for resource-based only when the workload's shape and location are genuinely stable, and take the higher rate for that certainty.
 
 ```bash
 # Create a resource-based CUD (Compute Engine)
+# Commitment types are lowercase-hyphenated: general-purpose, general-purpose-n2,
+# compute-optimized, memory-optimized, and so on.
 gcloud compute commitments create my-commitment \
   --region=us-central1 \
   --plan=36-month \
   --resources=vcpu=100,memory=400GB \
-  --type=GENERAL_PURPOSE
+  --type=general-purpose
 
 # Create a spend-based CUD
 # (Done through Cloud Console or API, not gcloud CLI for spend-based)
@@ -1433,11 +1433,12 @@ gcloud compute commitments describe my-commitment --region=us-central1
 ```
 
 **Key CUD facts:**
-- Resource-based CUDs are regional. A commitment in `us-central1` does not apply to VMs in `us-east1`.
-- Resource-based CUDs apply across VM families within the commitment type (general-purpose CUD covers N2, N2D, E2, etc.).
+- Resource-based CUDs are regional. A commitment in `us-central1` does not apply to VMs in `us-east1`. Flexible CUDs are not regional, which is their point.
+- Resource-based CUDs apply across VM families within the commitment type (a general-purpose CUD covers N2, N2D, E2 and so on).
+- **Resource-based CUDs do not cover Dataflow.** Dataflow bills under its own SKUs. This is a common wrong assumption because Dataflow runs on VMs.
 - CUDs are non-cancellable. If you overcommit, you still pay for the committed amount.
-- CUDs can be shared across projects within the same billing account (with CUD sharing enabled).
-- 1-year CUDs give ~37% discount; 3-year CUDs give ~55-57% discount.
+- CUDs can be shared across projects within the same billing account, with CUD sharing enabled.
+- Resource-based: ~37% for 1-year, up to 55% for 3-year, up to 70% for memory-optimized. Flexible: ~28% and ~46%.
 
 ---
 
@@ -1447,23 +1448,33 @@ SUDs are automatic discounts for running Compute Engine resources for a signific
 
 **How SUDs Work:**
 - Computed monthly per region per resource type.
-- The more you use a resource type in a month, the higher the discount (up to 30% for running all month).
-- Applied automatically -- no commitment or action required.
-- Applies to GCE VMs, GKE nodes, and Dataproc clusters.
-- **Does NOT apply to:** E2 machines, sole-tenant nodes, preemptible/Spot VMs, or resources covered by CUDs.
+- Earned in quarters of the month. The more of the month a resource runs, the higher the discount.
+- Applied automatically. No commitment or action required.
+- Applies to Compute Engine VMs, GKE nodes, and **sole-tenant nodes, including the sole-tenancy premium**.
+- **Does NOT apply to:** E2 machines, Spot VMs, or resources already covered by CUDs.
 
 **SUD Discount Tiers:**
 
-| Usage (% of month) | Effective Discount |
+| Usage (% of month) | Discount earned on that portion |
 |--------------------|--------------------|
 | 0-25% | 0% (full price) |
-| 25-50% | ~8.3% |
-| 50-75% | ~16.7% |
-| 75-100% | ~30% |
+| 25-50% | 10% |
+| 50-75% | 20% |
+| 75-100% | 30% |
 
-> **Exam trap:** SUDs and CUDs do not stack. If a resource is covered by a CUD, it does not also get a SUD. CUDs provide better discounts, so they take priority.
+**The maximum depends on the machine family**, which is the part most people miss:
 
-> **Exam trap:** E2 machine types do NOT receive SUDs. This is a frequently tested gotcha. N1, N2, and C2 families do.
+| Family | Maximum SUD |
+|--------|-------------|
+| N1, M1, M2 | 30% |
+| N2, N2D, C2 | 20% |
+| E2 | none |
+
+> **Exam trap:** SUDs and CUDs do not stack. If a resource is covered by a CUD it does not also get a SUD. CUDs give the better rate, so they take priority.
+
+> **Exam trap:** E2 machine types receive no SUDs at all. N1, N2 and C2 do, but at different maximums, so "up to 30%" is only true for N1, M1 and M2. C2 is eligible despite being commonly listed as excluded.
+
+> **Exam trap:** sole-tenant nodes **do** earn SUDs. The sole-tenancy premium is discounted too, which is counter-intuitive because sole-tenancy is usually framed as the expensive option.
 
 ---
 
@@ -1703,9 +1714,10 @@ Budgets can trigger Pub/Sub messages, which can invoke Cloud Functions to take a
 |----------|---------|--------|----------|
 | **Delete idle resources** | Immediate | Low | Quick wins |
 | **Right-size VMs** | 20-50% per VM | Low | Overprovisioned workloads |
-| **Sustained Use Discounts** | Up to 30% | None (automatic) | Steady-state non-E2 VMs |
-| **1-Year CUDs** | ~37% | Medium (commitment) | Predictable workloads |
-| **3-Year CUDs** | ~55-57% | High (long commitment) | Stable, long-term workloads |
+| **Sustained Use Discounts** | Up to 30% (N1/M1/M2) or 20% (N2/N2D/C2) | None (automatic) | Steady-state non-E2 VMs |
+| **1-Year resource CUDs** | ~37% | Medium (commitment) | Predictable workloads, fixed region and family |
+| **3-Year resource CUDs** | Up to 55% (70% memory-optimized) | High (long commitment) | Stable, long-term workloads |
+| **Flexible CUDs** | ~28% (1yr), ~46% (3yr) | Medium | Compute spend that may move region or family |
 | **Spot VMs** | 60-91% | Medium (fault tolerance) | Batch, CI/CD, dev/test |
 | **Autoscaling** | Variable | Medium | Variable traffic patterns |
 | **BigQuery partitioning** | 50-90% per query | Low-Medium | Large BigQuery tables |
@@ -1713,8 +1725,9 @@ Budgets can trigger Pub/Sub messages, which can invoke Cloud Functions to take a
 | **Preemptible Dataproc** | 60-80% | Low | Batch analytics |
 
 **Exam tips:**
-- **CUDs vs SUDs:** CUDs require commitment, give bigger discounts (37-57%). SUDs are automatic, give up to 30%. They do NOT stack.
-- **Resource-based CUDs** are for Compute Engine. **Spend-based CUDs** are for Cloud SQL, Cloud Run, VMware Engine.
+- **CUDs vs SUDs:** CUDs require commitment and give the bigger discount (~37% for 1 year, up to 55% for 3, up to 70% memory-optimized). SUDs are automatic and cap at 30% for N1/M1/M2 or 20% for N2/N2D/C2. They do NOT stack.
+- **Three CUD types:** resource-based (Compute Engine and GKE, locked to region and family), flexible (compute spend, portable, ~28%/~46%), and spend-based per service (Cloud SQL, AlloyDB, Cloud Run, VMware Engine, BigQuery editions).
+- **Flexible CUDs are the current default recommendation** when the workload might move. If a question stresses changing requirements or multi-region, the flexible CUD is likely the answer even though its headline rate is lower.
 - **E2 machines do NOT get SUDs.** This is a trap.
 - **Spot VMs require fault tolerance.** If the question says "mission-critical" or "cannot tolerate interruption," Spot is wrong.
 - **Budgets alert but do not stop spending.** Programmatic enforcement requires Pub/Sub + Cloud Functions.

--- a/gcp/pca/docs/06-solution-operations-excellence.md
+++ b/gcp/pca/docs/06-solution-operations-excellence.md
@@ -72,17 +72,16 @@ Cloud Monitoring is the central metrics, dashboards, and alerting platform in Go
 | **Log-based metrics** | Derived from Cloud Logging | Counter or distribution from log entries | 24 months |
 
 ```bash
-# List available metric descriptors for a project
-gcloud monitoring metrics-descriptors list \
-  --filter='metric.type = starts_with("compute.googleapis.com/instance/cpu")'
+# There is no `gcloud monitoring metrics-descriptors` group. The GA groups under
+# `gcloud monitoring` are exactly: dashboards, policies, snoozes, uptime.
+# Metric descriptors are managed through the Monitoring API v3 or a client library.
 
-# Create a custom metric descriptor
-gcloud monitoring metrics-descriptors create \
-  custom.googleapis.com/orders/per_minute \
-  --type=custom.googleapis.com/orders/per_minute \
-  --metric-kind=GAUGE \
-  --value-type=INT64 \
-  --description="Orders processed per minute"
+# List metric descriptors via the API
+curl -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+  "https://monitoring.googleapis.com/v3/projects/PROJECT_ID/metricDescriptors?filter=metric.type=starts_with(\"compute.googleapis.com/instance/cpu\")"
+
+# Custom metric descriptors are normally created implicitly by writing the first
+# data point from a client library, or explicitly via metricDescriptors.create.
 
 # Write a custom metric data point (typically done via client library, not CLI)
 # Python example:
@@ -230,11 +229,10 @@ gcloud monitoring policies describe POLICY_ID
 gcloud monitoring policies update POLICY_ID --enabled
 gcloud monitoring policies update POLICY_ID --no-enabled
 
-# List notification channels
-gcloud monitoring channels list
+# Notification channels are on the beta track, not GA.
+gcloud beta monitoring channels list
 
-# Create a notification channel
-gcloud monitoring channels create \
+gcloud beta monitoring channels create \
   --display-name="Ops Team Email" \
   --type=email \
   --channel-labels=email_address=ops@example.com
@@ -631,7 +629,7 @@ Error Reporting aggregates and displays errors from cloud services, automaticall
 
 # View error groups (typically done in Console > Error Reporting)
 # Or via API:
-gcloud beta error-events list --service=my-service --limit=10
+gcloud beta error-reporting events list --service=my-service --limit=10
 ```
 
 **Exam tips:**
@@ -736,8 +734,9 @@ Alerting policies can combine multiple conditions:
 | **Mobile app** | Google Cloud mobile app push notifications | Seconds |
 
 ```bash
-# Create a Pub/Sub notification channel (for automated remediation)
-gcloud monitoring channels create \
+# Create a Pub/Sub notification channel (for automated remediation).
+# Notification channels are beta, not GA.
+gcloud beta monitoring channels create \
   --display-name="Auto-Remediation" \
   --type=pubsub \
   --channel-labels=topic=projects/PROJECT_ID/topics/alert-notifications
@@ -1346,21 +1345,27 @@ Error Budget (from SLO):
 # Create a service (for SLO attachment)
 # Services are auto-detected for App Engine, Cloud Run, GKE, Istio
 
-# Create an availability SLO
-gcloud monitoring slos create \
-  --service=my-service \
-  --display-name="Availability SLO" \
-  --goal=0.999 \
-  --rolling-period=30d \
-  --request-based-sli \
-  --good-total-ratio-filter='metric.type="loadbalancing.googleapis.com/https/request_count" AND metric.labels.response_code_class="200"' \
-  --total-ratio-filter='metric.type="loadbalancing.googleapis.com/https/request_count"'
+# There is no `gcloud monitoring slos` group on any track. SLOs are created
+# through the Monitoring API v3, Terraform, or the console. Terraform is the
+# form worth knowing for the exam, because SLOs belong in version control.
 
-# List SLOs for a service
-gcloud monitoring slos list --service=my-service
+resource "google_monitoring_slo" "availability" {
+  service      = google_monitoring_custom_service.api.service_id
+  display_name = "Availability SLO"
 
-# Describe an SLO (shows current compliance)
-gcloud monitoring slos describe SLO_ID --service=my-service
+  goal                = 0.999
+  rolling_period_days = 30
+
+  request_based_sli {
+    good_total_ratio {
+      good_service_filter  = "metric.type=\"loadbalancing.googleapis.com/https/request_count\" AND metric.labels.response_code_class=\"200\""
+      total_service_filter = "metric.type=\"loadbalancing.googleapis.com/https/request_count\""
+    }
+  }
+}
+
+# Read current compliance via the API
+# GET https://monitoring.googleapis.com/v3/projects/PROJECT_ID/services/SERVICE_ID/serviceLevelObjectives
 ```
 
 **Exam tips:**

--- a/gcp/pca/docs/07-well-architected-framework.md
+++ b/gcp/pca/docs/07-well-architected-framework.md
@@ -135,14 +135,14 @@ Layer 4: Security/Audit (who did what, when)
 # Create an alerting policy for high error rate
 gcloud monitoring policies create --policy-from-file=error-rate-policy.yaml
 
-# Create a notification channel
-gcloud monitoring channels create \
+# Create a notification channel (beta track, not GA)
+gcloud beta monitoring channels create \
   --type=email \
   --display-name="On-Call Team" \
   --channel-labels=email_address=oncall@company.com
 
-# View SLO compliance
-gcloud monitoring slos list --service=my-service
+# SLOs have no gcloud surface. Define them in Terraform with
+# google_monitoring_slo, or read compliance from the Monitoring API v3.
 
 # Create a log-based metric
 gcloud logging metrics create high_latency_requests \
@@ -355,10 +355,15 @@ gcloud resource-manager org-policies enable-enforce \
   constraints/compute.requireOsLogin \
   --organization=123456789
 
-# Disable external IP addresses on VMs
-gcloud resource-manager org-policies enable-enforce \
-  constraints/compute.vmExternalIpAccess \
-  --organization=123456789
+# Disable external IP addresses on VMs.
+# vmExternalIpAccess is a LIST constraint, so enable-enforce does not apply to it.
+# enable-enforce is only for boolean constraints.
+gcloud org-policies set-policy vm-external-ip-deny.yaml --organization=123456789
+# where the policy file denies all values:
+#   name: organizations/123456789/policies/compute.vmExternalIpAccess
+#   spec:
+#     rules:
+#     - denyAll: true
 
 # Restrict VPC peering to approved networks
 gcloud resource-manager org-policies set-policy \
@@ -708,7 +713,7 @@ Region A (us-central1)              Region B (us-east1)
 
 - **Cloud SQL HA is NOT multi-region**: Regional HA with a standby in a different zone is automatic failover within ONE region. Cross-region requires read replicas with manual promotion.
 - **Spanner multi-region configs**: Know the named configs -- `nam14` (North America), `eur6` (Europe), `nam-eur-asia1` (global). These provide zero RPO and automatic failover.
-- **Cloud Storage classes and availability**: Multi-regional = 99.95%, Regional = 99.9%, Nearline/Coldline/Archive = 99.0%/99.0%/99.0%. Archive is NOT slower to read -- it just has higher retrieval costs and minimum storage duration (365 days).
+- **Cloud Storage classes and availability**: the SLA depends on **class and location together**, not class alone. Standard is 99.95% in multi-region or dual-region and 99.9% in a single region. Nearline, Coldline and Archive are 99.9% in multi-region or dual-region and 99.0% in a single region. Archive is NOT slower to read -- it has millisecond first-byte latency like the rest, and its cost is in retrieval charges plus a 365-day minimum storage duration.
 - **Global vs Regional Load Balancer**: If the question mentions multi-region backend or anycast IP, the answer is **global**. If it mentions data sovereignty or single-region, the answer is **regional**.
 - **GKE regional cluster**: The control plane runs in 3 zones automatically. Node pools can be single-zone or multi-zone. For HA, always use **regional clusters with multi-zone node pools**.
 - **RPO = 0 requires synchronous replication**: Only achievable with services like Spanner multi-region, Cloud Storage multi-regional, or Firestore multi-region. Async replication always has RPO > 0.
@@ -745,8 +750,9 @@ Cost optimization is about achieving business outcomes at the lowest price point
 | Model | Description | Discount | Commitment |
 |-------|-------------|----------|------------|
 | **On-demand** | Pay per second/minute/hour | None (baseline) | None |
-| **Sustained Use Discounts (SUDs)** | Automatic discounts for running VMs 25%+ of a month | Up to **20%** | None (automatic) |
-| **Committed Use Discounts (CUDs)** | 1-year or 3-year resource commitments | **20-57%** | 1 or 3 years |
+| **Sustained Use Discounts (SUDs)** | Automatic discounts for running VMs 25%+ of a month | Up to **30%** (N1/M1/M2) or **20%** (N2/N2D/C2) | None (automatic) |
+| **Resource-based CUDs** | 1-year or 3-year commitment to vCPU and memory in a region | **~37%** (1yr), up to **55%** (3yr), up to **70%** memory-optimized | 1 or 3 years |
+| **Flexible CUDs** | Commitment to compute spend, portable across region and family | **~28%** (1yr), **~46%** (3yr) | 1 or 3 years |
 | **Spot VMs (Preemptible)** | Interruptible VMs at steep discounts | **60-91%** | None (can be reclaimed anytime) |
 | **Flat-rate pricing** | BigQuery, Spanner capacity-based pricing | Varies | Edition commitment |
 | **Free tier** | Always-free products and limits | 100% (within limits) | None |
@@ -756,9 +762,10 @@ Cost optimization is about achieving business outcomes at the lowest price point
 ```
 Is the workload predictable (stable baseline)?
 ├── YES: Will it run for 1+ years?
-│   ├── YES (3+ years) → 3-year CUD (largest discount: ~57% for memory-optimized)
-│   ├── YES (1-3 years) → 1-year CUD (~20-37% discount)
-│   └── YES (< 1 year) → Let SUDs apply automatically
+│   ├── YES: is the region and machine family also fixed?
+│   │   ├── YES → resource-based CUD (up to 55%, up to 70% memory-optimized)
+│   │   └── NO  → flexible CUD (~46% at 3 years, portable across region and family)
+│   └── NO (< 1 year) → let SUDs apply automatically
 └── NO: Is it fault-tolerant / batch processing?
     ├── YES → Spot VMs (60-91% discount, but can be preempted)
     └── NO → On-demand with autoscaling
@@ -828,7 +835,7 @@ gcloud sql instances patch my-instance \
 ```
 
 **Label strategy best practices:**
-- Enforce required labels via **Org Policy** (`constraints/compute.requireLabels`)
+- Enforce required labels at apply time with policy-as-code (Terraform validation, `gcloud beta terraform vet`, or Policy Controller). There is no `constraints/compute.requireLabels` org policy. For governance that must be enforced by the platform rather than the pipeline, use **tags** with `resourcemanager` constraints, since tags are IAM-controlled and labels are not
 - Standard labels: `team`, `env`, `cost-center`, `app`, `owner`, `managed-by`
 - Use labels in billing exports for team/project chargeback dashboards
 
@@ -1021,9 +1028,9 @@ Performance optimization ensures that resources are used efficiently to meet sys
 | Hardware | Service | Use Case | Performance Gain |
 |----------|---------|----------|-----------------|
 | **NVIDIA GPUs** (T4, L4, A100, H100) | Compute Engine, GKE, Vertex AI | ML training/inference, rendering | 10-100x for parallel workloads |
-| **Cloud TPU** (v4, v5e, v5p) | TPU VMs, Vertex AI, GKE | Large language model training | Purpose-built for TensorFlow/JAX |
+| **Cloud TPU** (v5e, v5p, v6e Trillium, v7 Ironwood) | TPU VMs, Vertex AI, GKE | Large language model training | Purpose-built for JAX/XLA and TensorFlow |
 | **Local SSD** | Compute Engine, GKE | High-IOPS temporary storage | 680K read IOPS, 360K write IOPS |
-| **Hyperdisk** | Compute Engine, GKE | High-throughput persistent storage | Up to 2.4 TB/s throughput |
+| **Hyperdisk** | Compute Engine, GKE | High-throughput persistent storage | Balanced up to 2,400 MiB/s per volume; Extreme up to 5,000 MiB/s; ML up to ~2 TiB/s |
 | **Persistent Disk (pd-ssd)** | Compute Engine, GKE | General high-performance persistent | 100K IOPS per VM |
 
 ### Architect-Level Considerations
@@ -1289,8 +1296,11 @@ Energy savings: Reduced storage footprint. Archive class uses less active infras
 ```
 
 ```bash
-# View Carbon Footprint data via API
-gcloud beta carbon-footprint get \
+# There is no `gcloud carbon-footprint` command group. Carbon Footprint data is
+# consumed through its BigQuery export or the console.
+# The export is configured in Billing, then queried like any other dataset.
+# Legacy example kept below for shape only; do not run it.
+# gcloud beta carbon-footprint get \
   --billing-account=BILLING_ACCOUNT_ID
 
 # Or access via BigQuery export:

--- a/gcp/pca/docs/10-key-commands-and-terraform.md
+++ b/gcp/pca/docs/10-key-commands-and-terraform.md
@@ -180,10 +180,10 @@ gcloud ai endpoints deploy-model ENDPOINT_ID \
 # List models
 gcloud ai models list --region=us-central1
 
-# Create a pipeline run
-gcloud ai pipelines runs create \
-  --region=us-central1 --display-name=my-pipeline \
-  --template-uri=gs://my-bucket/pipeline.yaml
+# There is no `pipelines` group under `gcloud ai`. Pipelines are submitted from
+# the Python SDK or the REST API:
+#   from google.cloud import aiplatform
+#   aiplatform.PipelineJob(template_path=..., display_name=...).submit()
 ```
 
 ### Cloud Deploy


### PR DESCRIPTION
## Summary

Two classes of error across five study guides. Both are cheap to lose marks on, and the cost one spans sections 1 and 4, which together are ~40% of the exam.

## Commands that do not exist

A guide teaching a command that returns `unrecognized` costs more than a missing topic, because it undermines trust in everything near it.

| Was | Reality |
|---|---|
| `gcloud ai pipelines run/schedules create`, `gcloud ai batch-prediction-jobs create` | Neither group exists. Both are SDK, REST or console only |
| `gcloud monitoring slos create/list/describe` | **No `slos` group on any track.** Matters most, because 6.5 *is* the SLO objective |
| `gcloud monitoring metrics-descriptors` | No such group. The GA groups are `dashboards`, `policies`, `snoozes`, `uptime` |
| `gcloud monitoring channels` | Beta, not GA. Wrong in three places |
| `gcloud beta error-events list` | `gcloud beta error-reporting events list` |
| `gcloud beta carbon-footprint get` | No such group. Data comes from the BigQuery export |
| `gcloud privatecatalog catalogs/products create` | Search-only surface. Product is now Service Catalog |
| `gcloud dlp inspect-content` / `deidentify-content` | `gcloud alpha dlp text inspect` / `redact` |
| `--enable-vulnerability-scanning` | `--allow-vulnerability-scanning`. Two files |
| `constraints/compute.requireLabels` | **Does not exist.** Label governance is policy-as-code, or tags |
| `enable-enforce` on `compute.vmExternalIpAccess` | It's a list constraint and needs `set-policy`. The three neighbouring constraints *are* boolean, which is what made this hard to spot |

Where a command had no real equivalent, it's replaced with the form the exam actually tests: the Python SDK for Vertex AI pipelines, the `google_monitoring_slo` Terraform resource for SLOs.

## Cost figures

These contradicted each other across three files, and omitted the discount model Google now leads with.

- **Compute flexible CUDs were absent from the entire repo.** ~28% for 1 year, ~46% for 3, portable across region and machine family, and they cover Cloud Run and GKE Autopilot. That combination makes them a likely current exam item, and there was nothing to study. Added to docs 01, 02, 04 and 07 with a decision rule for when to prefer them over resource-based.
- **CUD rates said 57%** in four places. Resource-based is up to 55%, and up to 70% for memory-optimized.
- **SUD said a flat "up to 30%".** The cap is family-dependent: 30% for N1/M1/M2, 20% for N2/N2D/C2. The old text would have you confidently wrong on an N2 question.
- **The SUD tier table read 8.3 / 16.7 / 30%.** The tiers are 0 / 10 / 20 / 30%.
- **doc 01 said C2 gets no SUDs; doc 04 correctly said it does.** doc 04 said sole-tenant nodes get no SUDs; they do, including on the sole-tenancy premium, which is counter-intuitive enough to be worth testing.
- **Resource-based CUDs were said to cover Dataflow.** They don't; Dataflow bills under its own SKUs. Easy to assume wrong because Dataflow runs on VMs.
- `--type=GENERAL_PURPOSE` corrected to `general-purpose`.

## Also fixed while in these files

- **Hyperdisk throughput given as 2.4 TB/s**, off by ~1000x. Balanced is 2,400 MiB/s per volume, Extreme 5,000 MiB/s, and only Hyperdisk ML approaches 2 TiB/s.
- **The Cloud Storage SLA bullet collapsed class and location into one axis** and got the multi-region cold-class figure wrong. It now matches the correct table already in doc 02. This was the original contradiction that started the whole audit.
- A TPU list that stopped at v5, now including Trillium (v6e) and Ironwood (v7).