### PR TITLE
fix(pca): errata sweep for docs 03 and 04

### DIFF
--- a/.claude/state/research/2026-08-09-pca-content-audit.md
+++ b/.claude/state/research/2026-08-09-pca-content-audit.md
@@ -78,9 +78,10 @@ A learner who types these gets "unrecognized". Highest-confusion class of error.
 - [x] `docs/03:769-777` - `gcloud dlp inspect-content` / `deidentify-content`. Actual surface is `gcloud alpha dlp text inspect` / `redact`.
 - [x] `docs/03:611-614` and `04:385-387` - `--enable-vulnerability-scanning`. Real flag is `--allow-vulnerability-scanning`.
 - [x] `docs/04:77-84` and `06:1350-1363` and `07:145` - `gcloud monitoring slos create/list/describe`. No `slos` group. SLOs come from the Monitoring API v3, Terraform `google_monitoring_slo`, or the console. Significant because 6.5 is the SLO objective.
-- [ ] `docs/04:713-717` - `gcloud logging metrics create --bucket-options=...`. No such flag; distribution metrics need `--config-from-file`.
+- [x] `docs/04:713-717` - `gcloud logging metrics create --bucket-options=...`. No such flag; distribution metrics need `--config-from-file`.
 - [x] `docs/04:889-898` - `gcloud privatecatalog catalogs create` / `products create`. Not real; the surface is search-only. Product also renamed to Service Catalog in 2022.
-- [ ] `docs/04:1352-1357` - `gcloud monitoring policies create --condition-display-name/--condition-filter/--condition-threshold-value`. Invented flags; takes `--policy` / `--policy-from-file`.
+- [x] `docs/04:1352-1357` - `gcloud monitoring policies create --condition-display-name/--condition-filter/--condition-threshold-value`. Invented flags; takes `--policy` / `--policy-from-file`.
+  Note: `--condition-display-name` and `--condition-filter` do exist; only `--condition-threshold-value` is invented (thresholds use `--if`). Example rewritten to `--policy-from-file` regardless, since the flag form cannot express the condition shown.
 - [x] `docs/06:76`, `06:80-85` - `gcloud monitoring metrics-descriptors list/create`. No such group on any track. GA groups are dashboards, policies, snoozes, uptime.
 - [x] `docs/06:234`, `06:237-240`, `07:139-142` - `gcloud monitoring channels`. Beta only.
 - [x] `docs/06:634` - `gcloud beta error-events list`. Correct group is `gcloud beta error-reporting events list`.
@@ -114,7 +115,8 @@ A learner who types these gets "unrecognized". Highest-confusion class of error.
 - [ ] `docs/02:272-277`, `02:323` - firewall precedence order wrong for the default `AFTER_CLASSIC_FIREWALL` enforcement.
 - [ ] `docs/02:740`, `02:751`, `01:237` - three different Transfer Appliance capacities, all retired. Current models are TA40 (40 TB) and TA300 (300 TB).
 - [ ] `docs/02:1089` - M2 listed as "12-416" vCPUs. M2 starts at 208. M1 and M4 missing entirely.
-- [ ] `docs/03:252` - SDP "150+ built-in detectors". Actual 200+.
+- [x] `docs/03:252` - SDP "150+ built-in detectors". Actual 200+.
+  Could not confirm any published count. The infoTypes reference page explicitly declines to give one and tells you to call `infoTypes.list`. Replaced the number with that instruction rather than swapping one unverifiable figure for another.
 - [ ] `docs/09:311` - Interconnect 99.9% SLA needs two connections in different edge availability domains, not just one metro.
 - [ ] `docs/09:305`, `09:309`, `09:367` - Dedicated Interconnect "10-200 Gbps". Now 10, 100 and 400 Gbps link types.
 - [ ] `docs/09:322`, `09:329`, `09:369` and `02:22` - HA VPN "3 Gbps per tunnel". Documented limit is 250,000 packets/sec, which is 1-3 Gbps depending on packet size.
@@ -125,20 +127,21 @@ A learner who types these gets "unrecognized". Highest-confusion class of error.
 
 ## P1 - facts that are wrong but not numeric
 
-- [ ] `docs/04:305` - "the `images` field does NOT push to a registry". It does. Stated as an exam tip, which makes it worse.
-- [ ] `docs/04:301` - Cloud Build default SA. New projects default to the Compute Engine default SA, not `{PROJECT_NUMBER}@cloudbuild.gserviceaccount.com`.
+- [x] `docs/04:305` - "the `images` field does NOT push to a registry". It does. Stated as an exam tip, which makes it worse.
+- [x] `docs/04:301` - Cloud Build default SA. New projects default to the Compute Engine default SA, not `{PROJECT_NUMBER}@cloudbuild.gserviceaccount.com`.
 - [ ] `docs/04:788`, `04:795`, `04:869` and `05:270` and `07:660` - "Cloud Load Testing" as a Google product, with a doc link that does not resolve. No such product has ever existed.
-- [ ] `docs/04:539-543`, `04:667` - "Cloud Deploy rollback means creating a new release". Native rollback exists (`gcloud deploy targets rollback`) plus automated rollback rules.
-- [ ] `docs/04:668` - "Cloud Deploy canary requires a service mesh". It supports plain Kubernetes service networking.
-- [ ] `docs/04:693` - Cloud Debugger "replaced by Snapshot Debugger". Both are gone; delete the row.
-- [ ] `docs/04:1015` - "Memorystore Redis cross-region replication, Standard tier". Standard tier is cross-zone within one region. Cross-region is a Redis Cluster / Valkey feature.
+  `docs/04` done: all three sites replaced with the Architecture Center guide "Distributed load testing using GKE", plus an explicit callout that no such product exists. `05:270` and `07:660` still open.
+- [x] `docs/04:539-543`, `04:667` - "Cloud Deploy rollback means creating a new release". Native rollback exists (`gcloud deploy targets rollback`) plus automated rollback rules.
+- [x] `docs/04:668` - "Cloud Deploy canary requires a service mesh". It supports plain Kubernetes service networking.
+- [x] `docs/04:693` - Cloud Debugger "replaced by Snapshot Debugger". Both are gone; delete the row.
+- [x] `docs/04:1015` - "Memorystore Redis cross-region replication, Standard tier". Standard tier is cross-zone within one region. Cross-region is a Redis Cluster / Valkey feature.
 - [x] `docs/04:1414` - resource-based CUDs cover Dataflow. They do not.
-- [ ] `docs/04:1291` - "AlloyDB single-region only". AlloyDB supports cross-region replication.
-- [ ] `docs/03:226-227` - "Key Access Justifications only available with EKM". KAJ works on software and HSM keys too.
-- [ ] `docs/03:583`, `03:641` - "Binary Authorization is for GKE". Also Cloud Run, Cloud Service Mesh, Google Distributed Cloud. Contradicts `04:397`.
-- [ ] `docs/03:620-624` - SLSA "Level 1-4". v1.0 Build track has L1-L3 only.
-- [ ] `docs/03:812` - "Artifact Hub" for compliance reports. Not a Google product. Correct: Compliance Reports Manager, and Audit Manager for evidence generation.
-- [ ] `docs/03:853` - Access Transparency "Premium or Enterprise support". Actual: Standard, Enhanced or Premium. Enterprise is not a Care tier.
+- [x] `docs/04:1291` - "AlloyDB single-region only". AlloyDB supports cross-region replication.
+- [x] `docs/03:226-227` - "Key Access Justifications only available with EKM". KAJ works on software and HSM keys too.
+- [x] `docs/03:583`, `03:641` - "Binary Authorization is for GKE". Also Cloud Run, Cloud Service Mesh, Google Distributed Cloud. Contradicts `04:397`.
+- [x] `docs/03:620-624` - SLSA "Level 1-4". v1.0 Build track has L1-L3 only.
+- [x] `docs/03:812` - "Artifact Hub" for compliance reports. Not a Google product. Correct: Compliance Reports Manager, and Audit Manager for evidence generation.
+- [x] `docs/03:853` - Access Transparency "Premium or Enterprise support". Actual: Standard, Enhanced or Premium. Enterprise is not a Care tier.
 - [ ] `docs/06:325` - "Policy Denied logs can exempt specific users". No principal-exemption mechanism; only a Log Router exclusion filter.
 - [ ] `docs/06:1712` - Web Security Scanner "App Engine and Cloud Run". Actual: App Engine, GKE, Compute Engine. Cloud Run not supported. Contradicts `06:1699` two lines earlier.
 - [ ] `docs/06:1993` - VM Manager metadata key `enable-os-config`. Correct key is `enable-osconfig`.
@@ -178,19 +181,24 @@ The Vertex AI rebrand is the big one and is a rewrite, not a find-and-replace.
 - [?] **Vertex AI to Gemini Enterprise Agent Platform.** Rebranded at Cloud Next 2026; Vertex AI left the Console 2026-05-21. "Vertex AI Agent Builder" appears as a *correct answer* in `section-1-designing-planning.md:659` and `:1094`, `section-2-provisioning-infrastructure.md:661`, `case-study-questions.md:207`. Model tables reference SKUs that now 404 (`docs/02:2098-2100`, `02:2190`, `01:787`). Affects docs 01, 02, 09.
   **Decision needed:** the v6.1 exam guide (Oct 2025) still uses Vertex AI naming. Recommendation is to keep exam-guide names primary and add a "now marketed as" note, rather than rewriting to names the exam does not use.
 - [ ] **Anthos to GKE Enterprise**, **Anthos Service Mesh + Traffic Director to Cloud Service Mesh**: `docs/01:279`, `01:641`, `01:742`, `01:1043`, `02:425`, `02:1505`, `04:429`, `04:668`, `04:749`, `04:790`, `04:820`, `04:972`, `06:788`, `06:1586`, `06:1660`, `06:1674`, `07:102`, `07:469`, `07:1005`, `07:1388`, `05:115`.
+  All six `docs/04` sites done. Docs 01, 02, 05, 06, 07 still open.
 - [ ] **Container Registry shut down** (writes 2025-03-18, reads 2025-06-03) but `gcr.io` still used in examples: `docs/02:1363`, `02:1370`, `05:297`, `05:301`, `05:305`, `05:1671`, `06:867`, `06:892`, `06:976`, `06:1000`, `07:178`. Also listed as a VPC-SC protectable service at `03:369`.
+  `03:369` done: Container Registry removed from the VPC-SC list with the shutdown dates stated. `docs/04` deliberately keeps its `gcr.io/cloud-builders/*` references, which are Google-owned images whose gcr.io URLs are served from Artifact Registry and are explicitly unaffected by the shutdown; a note in `04` now says so, since a blanket find-and-replace would break those examples.
 - [ ] **Cloud Functions to Cloud Run functions**: `docs/01:1018`, `05:169`, `05:216`, `05:238`, `06:622`, `06:641`, `07:562`, `07:977`, `07:803`, `07:1109`, `07:1231`, `questions/section-5-managing-implementations.md:229`, `:531`.
 - [ ] **Dataproc to Managed Service for Apache Spark**: `docs/09:62-66`, `09:93`, `09:100`, `09:891`, `09:1002`.
 - [ ] **Migrate for Compute Engine to Migrate to Virtual Machines**: `docs/09:835`, `09:889`, `09:903`, `09:1033`, `05:399`, `05:555`. M4CE v4.11 end of support 2024-04-30.
 - [ ] **BeyondCorp Enterprise to Chrome Enterprise Premium**: `questions/section-3-security-compliance.md:749`.
 - [ ] **Cloud Operations Suite to Google Cloud Observability**: `docs/01:414`, `07:222`, `07:1476`.
 - [ ] **Cloud Source Repositories** closed to new customers 2024-06-17, presented as live: `docs/01:180`, `04:28`, `04:580`. Successor is Secure Source Manager.
+  Both `docs/04` sites done, plus a naming-trap callout. `01:180` still open.
 - [ ] **Deployment Manager** past end of support 2026-03-31, new users blocked from 2026-06-30: `docs/05:1809-1841`, `09:937-941`, `09:967`, `09:974`, `10:592`, `10:600`, `04:881`.
+  `04:881` done. Docs 05, 09, 10 still open.
 - [ ] **Memorystore for Memcached deprecated** (no new instances after 2027-02-01, shutdown 2029-01-31): `docs/09:174`, `09:191`. Memorystore for Valkey missing entirely from the in-memory branch.
 - [ ] **PaLM 2 and Codey retired** April 2025: `docs/02:2156`, `09:634`.
 - [ ] **Model Armor is under Security Command Center**, not Vertex AI: `questions/section-3-security-compliance.md:654`, `docs/03:650-654` (also wrong doc URL).
+  `docs/03:650-654` done: rewritten around the real capability set (prompt injection, jailbreak, malicious URL, SDP integration), the two modes, templates and floor settings, with SCC doc URLs. The question file is still open.
 - [ ] **Cloud Armor Managed Protection Plus to Cloud Armor Enterprise**: `docs/02:214`.
-- [ ] **Private Catalog to Service Catalog** (renamed March 2022): `docs/04:879`, `04:936-937`.
+- [x] **Private Catalog to Service Catalog** (renamed March 2022): `docs/04:879`, `04:936-937`.
 - [ ] **Terraform Cloud to HCP Terraform**: `docs/05:1262`.
 - [ ] **gsutil to gcloud storage.** gsutil leaves the CLI bundle March 2027. `docs/10:806-825` gives gsutil its own section while `gcloud storage` is absent. Invert the emphasis but keep gsutil, since the exam guide still names it.
 - [ ] Dated version pins that will rot: TPU v3 (`questions/section-1-designing-planning.md:472`), GKE 1.28/1.29 (`section-6:587`), pd-ssd with no Hyperdisk (`section-2:492`), provider `~> 5.0` (`docs/10:285-294`, `05:1122-1129`) against a current 7.x, `POSTGRES_15` (`10:505`), CFT module pins (`10:412`, `10:427`).
@@ -221,19 +229,21 @@ The Vertex AI rebrand is the big one and is a rewrite, not a find-and-replace.
 
 - [ ] **Google Cloud VMware Engine** - named verbatim in objective 2.3, zero mentions anywhere. Belongs in `docs/02` under 2.3.
 - [ ] **Infrastructure Manager** - Google's managed Terraform and the named Deployment Manager replacement. Absent from `docs/05` and `docs/09` section 10. Biggest single gap given v6.1 made IaC explicit.
-- [ ] **Confidential Computing** - Confidential VMs, Confidential GKE Nodes, Confidential Space. Absent from `docs/03`.
-- [ ] **Workforce Identity Federation** - absent; only Workload Identity Federation is covered (`docs/03:529-560`). The workforce/workload distinction is a classic trap.
-- [ ] **Privileged Access Manager** - the canonical answer for just-in-time elevation and break-glass. Missing from separation of duties (`docs/03:269-303`).
+- [x] **Confidential Computing** - Confidential VMs, Confidential GKE Nodes, Confidential Space. Absent from `docs/03`.
+- [x] **Workforce Identity Federation** - absent; only Workload Identity Federation is covered (`docs/03:529-560`). The workforce/workload distinction is a classic trap.
+- [x] **Privileged Access Manager** - the canonical answer for just-in-time elevation and break-glass. Missing from separation of duties (`docs/03:269-303`).
 - [ ] **Cloud NGFW Enterprise** - objective 2.1 names intrusion protection; `docs/02:247-266` covers only Cloud IDS, which is detection-only.
 - [ ] **Network Connectivity Center** - two passing rows (`docs/02:188`, `02:344`), absent from the `docs/09` connectivity tree. Objective 2.1 covers exactly this.
 - [ ] **Metrics scopes** - multi-project observability, arguably the architect-level Cloud Monitoring topic. Absent from `docs/06`.
 - [ ] **SLO composition across dependent services** - the multiplicative rule is a classic PCA calculation, absent.
 - [ ] **DORA metrics** - absent from all files despite Google owning the research and citing it throughout WAF.
-- [ ] **Cloud Customer Care tiers** - `docs/04:1327-1377` "customer success" is effectively a second SLO section. Exam items framed as customer success often resolve to picking a support tier, and there is no basis for that here.
+- [x] **Cloud Customer Care tiers** - `docs/04:1327-1377` "customer success" is effectively a second SLO section. Exam items framed as customer success often resolve to picking a support tier, and there is no basis for that here.
+  Basic / Standard / Enhanced / Premium table added with the three published response targets (Standard P2 4h, Enhanced P1 1h, Premium P1 15min) and the TAM discriminator. Prices deliberately omitted: not verified, and `docs/06:1226` already tracks the price errata separately.
 - [ ] **Dynamic Workload Scheduler** - objective 2.4's "optimizing for different consumption models" is exactly this. Absent.
 - [ ] **Gemini Enterprise** (objective 2.5: AI Agents and NotebookLM) - NotebookLM gets one row; AI Agents absent.
 - [ ] Missing decision trees in `docs/09`, ranked by expected yield: resource hierarchy / landing zone, network topology selection, data pipeline and ingestion, multi-tenancy isolation, identity and federation, CI/CD topology, AI/ML serving, caching strategy, observability and logging architecture, cost optimization, compliance and data residency, encryption key strategy.
 - [ ] Thin relative to weight: securing AI (`docs/03:648-681`, 33 lines for a named objective), envisioning future improvements (`docs/01:1177-1237`, all of 1.5), success measurements (`docs/01:331-354`), Cloud Code (`docs/05:661-682`).
+  Securing AI partially addressed: the Model Armor block was rewritten and roughly doubled while fixing its product-family error. Still thin relative to the objective; a fuller build-out of the securing-AI section is not attempted here.
 - [ ] `docs/06:13-22` and `07:53-65` - the operational excellence "key principles" are hand-written SRE principles, not Google's published pillar principles. Objective 6.1 reads verbatim "the principles and recommendations of the operational excellence pillar", so a question quoting Google's wording would not be recognisable.
 
 ## P2 - effort is allocated inversely to exam weight (verified)
@@ -297,15 +307,17 @@ Keep as the model for rewrites: `docs/07:1392-1441` (pillar trade-off matrix, th
 ## P3 - structural defects
 
 - [ ] `docs/06:1166-1187` - the sample runbook is fenced but its internal markdown headings leak into the document outline, appearing as siblings of section 6.4.
-- [ ] `docs/04:1266-1288` - same problem with the ADR example's headings.
+- [x] `docs/04:1266-1288` - same problem with the ADR example's headings.
+  Replaced the fenced markdown ADR with a section table plus a bulleted worked example, so no `#` headings remain inside the block.
 - [ ] `docs/05:1809-1858` - IaC comparison table omits Infrastructure Manager.
 - [ ] `gcp/ace/docs/05-access-and-security.md:3` and `:1150` - `[Back to README](./README.md)` links to a file that does not exist; the README is one level up.
 - [ ] **ACE exam weights disagree across four files.** `gcp/ace/README.md:25-28` says Domain 1 ~23%, Domain 2 ~30%; the doc H1s say ~20% and ~17.5% on the older 5-domain scheme. Root `CLAUDE.md` agrees with the README. Question file headers restate it a fourth time.
 - [ ] **Question counts are maintained in five places**: root `CLAUDE.md`, `.claude/domain-reference.md:130-135` and `:36-46`, `.claude/study-modes.md:15-31`, both exam READMEs, and inside each question file. Single source of truth should be the `Total questions: N` line in each question file.
 - [ ] **The Cloud Storage class table appears in 9 doc files** and has already diverged (see `07:711` vs `02:596` above). Same shape for the Spot VM 60-91% figure (4 PCA files) and CMEK snippets (9 files).
-- [ ] Example timestamps now in the past: `docs/03:59`, `03:68`, `03:200`.
+- [x] Example timestamps now in the past: `docs/03:59`, `03:68`, `03:200`. Rolled forward to 2027.
 - [ ] `docs/07:1207`, `07:1215-1221` - CFE scores from the 2021-2022 dataset. Either refresh or keep only the relative ordering.
-- [ ] `docs/04:1323` - doc link `cloud.google.com/architecture/architecture-decision-records` could not be confirmed to exist.
+- [x] `docs/04:1323` - doc link `cloud.google.com/architecture/architecture-decision-records` could not be confirmed to exist.
+  It exists: "Architecture decision records overview" in the Architecture Center, fetched 200. No change needed; link left in place.
 - [ ] Note: `cloud.google.com/*` doc URLs now 301-redirect to `docs.cloud.google.com/*`. Existing links all resolve, so this is not a defect, but new links should use the new host.
 
 ## Open items needing verification

--- a/gcp/pca/docs/03-security-and-compliance.md
+++ b/gcp/pca/docs/03-security-and-compliance.md
@@ -56,7 +56,7 @@ Conditions allow granting access only when specific criteria are met:
 |---------------|---------|----------|
 | Resource type | `resource.type == "storage.googleapis.com/Bucket"` | Limit role to specific resource types |
 | Resource name | `resource.name.startsWith("projects/my-project/zones/us-central1-a")` | Regional restrictions |
-| Time-based | `request.time < timestamp("2026-06-01T00:00:00Z")` | Temporary access |
+| Time-based | `request.time < timestamp("2027-06-01T00:00:00Z")` | Temporary access |
 | Resource tags | `resource.matchTag("env", "production")` | Tag-based access control |
 | IP-based | Via Access Context Manager (not direct IAM) | Network-based access |
 
@@ -65,7 +65,7 @@ Conditions allow granting access only when specific criteria are met:
 gcloud projects add-iam-policy-binding my-project \
   --member="user:contractor@example.com" \
   --role="roles/compute.instanceAdmin.v1" \
-  --condition='expression=request.time < timestamp("2026-06-01T00:00:00Z"),title=temp-access,description=Temporary contractor access'
+  --condition='expression=request.time < timestamp("2027-06-01T00:00:00Z"),title=temp-access,description=Temporary contractor access'
 ```
 
 **IAM Deny Policies:**
@@ -197,7 +197,7 @@ gcloud kms keys create my-key \
   --location=us-central1 \
   --purpose=encryption \
   --rotation-period=90d \
-  --next-rotation-time=2026-04-01T00:00:00Z
+  --next-rotation-time=2027-04-01T00:00:00Z
 
 # Encrypt data
 gcloud kms encrypt \
@@ -221,10 +221,10 @@ gcloud kms keys versions disable 1 \
 - Adds latency (external call for every operation)
 - For extreme compliance requirements (data sovereignty, hold-your-own-key)
 
-**Key Access Justifications:**
+**Key Access Justifications (KAJ):**
 - Shows reason why Google needs to access keys (customer support, maintenance, etc.)
 - Customer can approve/deny access
-- Only available with EKM
+- Works with all Cloud KMS protection levels -- `SOFTWARE`, `HSM`, `EXTERNAL` and `EXTERNAL_VPC`. It is not EKM-only, which is the trap
 
 **Secret Manager:**
 - Store API keys, passwords, certificates
@@ -249,7 +249,7 @@ gcloud secrets add-iam-policy-binding my-secret \
 
 **Sensitive Data Protection (formerly DLP):**
 - Inspect, classify, de-identify sensitive data
-- Supports 150+ built-in detectors (SSN, credit card, email, etc.)
+- Large and growing set of built-in infoType detectors (SSN, credit card, email, etc.). Google does not publish a fixed count -- the authoritative list comes from the `infoTypes.list` API
 - De-identification methods: masking, tokenization, bucketing, format-preserving encryption
 - Integrates with BigQuery, Cloud Storage, Datastore
 
@@ -261,8 +261,9 @@ gcloud secrets add-iam-policy-binding my-secret \
 - Key rings cannot be deleted once created
 - Destroying a key version has a 24-hour default scheduled destruction period (configurable)
 - CMEK + Cloud EKM = strongest key control for data sovereignty
+- "See and approve the reason for every Google key access" → Key Access Justifications. Do NOT reject an answer because the key is software or HSM rather than EKM
 
-**Docs:** [Cloud KMS](https://cloud.google.com/kms/docs), [Secret Manager](https://cloud.google.com/secret-manager/docs), [Sensitive Data Protection](https://cloud.google.com/sensitive-data-protection/docs), [Cloud EKM](https://cloud.google.com/kms/docs/ekm)
+**Docs:** [Cloud KMS](https://cloud.google.com/kms/docs), [Secret Manager](https://cloud.google.com/secret-manager/docs), [Sensitive Data Protection](https://cloud.google.com/sensitive-data-protection/docs), [Cloud EKM](https://cloud.google.com/kms/docs/ekm), [Key Access Justifications](https://cloud.google.com/assured-workloads/key-access-justifications/docs/overview)
 
 ---
 
@@ -295,11 +296,26 @@ gcloud kms keyrings add-iam-policy-binding my-ring \
   --role="roles/cloudkms.cryptoKeyEncrypterDecrypter"
 ```
 
+**Privileged Access Manager (PAM):**
+
+PAM is the managed answer for just-in-time elevation and break-glass access. Instead of holding a privileged role permanently, a principal requests it and holds it only for the grant window.
+
+| Concept | What it is |
+|---------|-----------|
+| **Entitlement** | Who may request, which roles are granted, maximum grant duration, whether justification or approval is required |
+| **Grant** | An activated entitlement. The roles are attached for the grant duration, then automatically revoked |
+| **Approval** | Optional approver step, up to two levels with five approvers per level |
+| **Scope** | Project, folder or organization. Narrow further inside that scope with IAM Conditions on the entitlement |
+
+PAM covers the elevation case that IAM Conditions with a hard-coded expiry timestamp only approximates: the access is requested, justified, approved, time-boxed and audited as one flow.
+
 **Exam tips:**
 - "Ensure no single person can access and manage encryption keys" → separate roles/cloudkms.admin from roles/cloudkms.cryptoKeyEncrypterDecrypter
 - Separation of duties questions test whether you understand that admin roles and usage roles should be held by different principals
+- "Just-in-time elevation", "break-glass", "temporary admin with approval and audit trail" → Privileged Access Manager, not a time-conditioned IAM binding and never a standing role
+- PAM grants are self-revoking. If a question stresses that elevated access must not linger, that is the discriminator
 
-**Docs:** [Separation of Duties](https://cloud.google.com/iam/docs/understanding-roles#separation_of_duties)
+**Docs:** [Separation of Duties](https://cloud.google.com/iam/docs/understanding-roles#separation_of_duties), [Privileged Access Manager](https://cloud.google.com/iam/docs/pam-overview)
 
 ---
 
@@ -366,7 +382,9 @@ gcloud access-context-manager perimeters dry-run create my-perimeter \
 ```
 
 **VPC-SC supported services (commonly tested):**
-BigQuery, Cloud Storage, Cloud SQL, Spanner, Bigtable, Pub/Sub, Dataflow, Dataproc, Cloud KMS, Vertex AI, Artifact Registry, Container Registry, Secret Manager, Cloud Functions, Cloud Run.
+BigQuery, Cloud Storage, Cloud SQL, Spanner, Bigtable, Pub/Sub, Dataflow, Dataproc, Cloud KMS, Vertex AI, Artifact Registry, Secret Manager, Cloud Run functions, Cloud Run.
+
+Container Registry is no longer a protectable service in its own right -- it was shut down (writes 2025-03-18, reads 2025-06-03) and Artifact Registry is the perimeter-protected registry.
 
 **Organization Policies as Security Guardrails:**
 
@@ -483,6 +501,38 @@ gcloud resource-manager org-policies set-policy cmek-policy.yaml \
 
 ---
 
+### Confidential Computing
+
+CMEK and CSEK protect data **at rest**. TLS protects data **in transit**. Confidential Computing closes the third gap: data **in use**, encrypted in memory by the CPU so neither the hypervisor nor a Google operator can read it. When a scenario says "even the cloud provider must not be able to see the data while it is being processed", the at-rest and in-transit answers are all wrong.
+
+| Product | What it is | Reach for it when |
+|---------|-----------|-------------------|
+| **Confidential VM** | Compute Engine instances with hardware-based memory encryption in a Trusted Execution Environment | A regulated workload needs in-use protection on plain VMs |
+| **Confidential GKE Nodes** | Node pools built on Confidential VM | The same requirement, but the workload is containerized on GKE |
+| **Confidential Space** | Hardened, attested TEE where mutually distrusting parties compute on pooled data | Multi-party data collaboration where no party -- including the operator -- may see the others' raw data |
+| **Google Cloud Attestation** | Remote verifier that issues identity tokens proving what is actually running in the TEE | The design needs proof of the workload, not just isolation of it |
+
+**Underlying technologies:**
+
+| Technology | Machine series |
+|-----------|----------------|
+| AMD SEV | N2D, C2D, C3D, C4D |
+| AMD SEV-SNP (adds tamper protection against a malicious hypervisor) | N2D |
+| Intel TDX | C3, C4, A3 |
+| NVIDIA Confidential Computing (extends the TEE to attached GPUs) | GPU machine types for confidential AI/ML |
+
+Confidential VM technology also backs confidential variants of Dataflow, Managed Service for Apache Spark and Vertex AI Workbench.
+
+**Exam tips:**
+- "Protect data in use" / "encrypted while being processed" → Confidential Computing. Not CMEK, which is at rest
+- "Two companies want to run a joint analysis without either seeing the other's raw data" → Confidential Space. A shared BigQuery dataset with column-level ACLs does not clear this bar
+- Confidential GKE Nodes is a node-pool property, so it constrains machine type selection. Expect trade-off questions on machine family availability
+- Enabling Confidential VM costs a memory-encryption performance overhead and narrows machine type choice -- it is not free, which is why "enable it everywhere" is usually the wrong answer
+
+**Docs:** [Confidential Computing](https://cloud.google.com/confidential-computing/docs/confidential-computing-overview), [Confidential VM](https://cloud.google.com/confidential-computing/confidential-vm/docs/confidential-vm-overview), [Confidential GKE Nodes](https://cloud.google.com/kubernetes-engine/docs/how-to/confidential-gke-nodes), [Confidential Space](https://cloud.google.com/confidential-computing/confidential-space/docs/confidential-space-overview)
+
+---
+
 ### Secure Remote Access
 
 **Identity-Aware Proxy (IAP):**
@@ -559,6 +609,21 @@ gcloud iam service-accounts add-iam-policy-binding my-sa@my-project.iam.gservice
   --role="roles/iam.workloadIdentityUser"
 ```
 
+**Workforce Identity Federation:**
+
+The counterpart to Workload Identity Federation, and the pair is a classic exam trap. Workload federates **machines**; workforce federates **people**. Workforce Identity Federation lets employees, partners and contractors sign in to Google Cloud with your existing IdP without ever provisioning them a Google Account or Cloud Identity user.
+
+| | Workload Identity Federation | Workforce Identity Federation |
+|---|---|---|
+| **Federates** | Applications, CI/CD jobs, external workloads | Human users and groups |
+| **Pool type** | Workload identity pool | Workforce pool (created at org level) |
+| **Protocols** | OIDC, SAML, AWS STS | OIDC, SAML 2.0 |
+| **Typical IdP** | GitHub Actions, GitLab CI, AWS, Azure | Microsoft Entra ID, AD FS, Okta |
+| **Principal** | `principalSet://iam.googleapis.com/projects/NUM/locations/global/workloadIdentityPools/POOL/...` | `principal://iam.googleapis.com/locations/global/workforcePools/POOL/subject/SUBJECT` |
+| **Replaces** | Service account keys | Directory sync into Cloud Identity |
+
+The workforce case is sync-less: identities stay in the external IdP rather than being copied into Cloud Identity with Google Cloud Directory Sync. That is the discriminator when a scenario refuses to duplicate its user directory.
+
 **OS Login:**
 - SSH access management through IAM (replaces SSH key management)
 - Users login with their Google identity
@@ -572,17 +637,19 @@ gcloud iam service-accounts add-iam-policy-binding my-sa@my-project.iam.gservice
 - "Temporary elevated access" → service account impersonation
 - "Manage SSH access through IAM" → OS Login
 - Workload Identity Federation is the preferred alternative to SA keys for external workloads
+- "Let employees sign in with the corporate IdP without creating Google Accounts" → Workforce Identity Federation. If the subject is a pipeline or an application, it is Workload Identity Federation instead
 
-**Docs:** [IAP](https://cloud.google.com/iap/docs), [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation), [OS Login](https://cloud.google.com/compute/docs/instances/managing-instance-access)
+**Docs:** [IAP](https://cloud.google.com/iap/docs), [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation), [Workforce Identity Federation](https://cloud.google.com/iam/docs/workforce-identity-federation), [OS Login](https://cloud.google.com/compute/docs/instances/managing-instance-access)
 
 ---
 
 ### Securing Software Supply Chain
 
 **Binary Authorization:**
-- Admission control for GKE -- only allows deploying container images that have been signed by trusted authorities
+- Deploy-time admission control -- only allows deploying container images that have been signed by trusted authorities
 - Based on attestations (cryptographic signatures)
 - Integrates with Artifact Registry vulnerability scanning
+- Supported platforms: **GKE, Cloud Run, Cloud Service Mesh, and Google Distributed Cloud software**. "Binary Authorization is GKE-only" is a distractor
 
 ```bash
 # Enable Binary Authorization on a GKE cluster
@@ -618,10 +685,15 @@ gcloud artifacts docker images scan us-central1-docker.pkg.dev/my-project/my-rep
 ```
 
 **SLSA Framework (Supply chain Levels for Software Artifacts):**
-- Level 1: Build process documented
-- Level 2: Automated build, version control
-- Level 3: Hardened build platform, provenance verification
-- Level 4: Two-person review, hermetic/reproducible build
+
+The v1.0 Build track defines **L1 to L3**. There is no L4 in v1.0 -- the two-person-review and hermetic-build requirements people remember as "Level 4" came from the pre-1.0 draft and were dropped.
+
+| Level | Requirement |
+|-------|-------------|
+| Build L0 | No guarantees. The absence of SLSA, not a level you claim |
+| Build L1 | Provenance exists: the package ships a record of how it was built |
+| Build L2 | Hosted build platform, provenance signed by that platform |
+| Build L3 | Hardened build platform with strong tamper protection on the provenance |
 
 **Cloud Build integration:**
 - Cloud Build can generate SLSA provenance metadata
@@ -638,21 +710,22 @@ gcloud artifacts docker images scan us-central1-docker.pkg.dev/my-project/my-rep
 - "Only allow verified images in production GKE" → Binary Authorization
 - "Scan container images for vulnerabilities" → Artifact Registry scanning
 - "Secure the entire CI/CD pipeline" → Software Delivery Shield
-- Binary Authorization works at the cluster level -- it's enforced on GKE admission
-- Artifact Registry replaces Container Registry (GCR) -- GCR is legacy
+- Binary Authorization is enforced at deploy time. On GKE that is cluster admission; on Cloud Run it is service deployment. Do not eliminate an option just because the platform is not GKE
+- Artifact Registry replaces Container Registry (GCR). Container Registry is shut down, not merely legacy
+- SLSA v1.0 stops at Build L3. An option offering "SLSA Level 4" is written from the old draft
 
-**Docs:** [Binary Authorization](https://cloud.google.com/binary-authorization/docs), [Artifact Registry](https://cloud.google.com/artifact-registry/docs), [Software Delivery Shield](https://cloud.google.com/software-supply-chain-security/docs/overview)
+**Docs:** [Binary Authorization](https://cloud.google.com/binary-authorization/docs), [Artifact Registry](https://cloud.google.com/artifact-registry/docs), [Software Delivery Shield](https://cloud.google.com/software-supply-chain-security/docs/overview), [SLSA levels](https://slsa.dev/spec/v1.0/levels)
 
 ---
 
 ### Securing AI
 
 **Model Armor:**
-- Content safety filters for AI/ML models
-- Screens prompts and responses for harmful content
-- Supports Vertex AI models and third-party models
-- Categories: hate speech, harassment, dangerous content, sexually explicit, self-harm
-- Configurable sensitivity levels
+- A **Security Command Center** service, not a Vertex AI feature. Getting the product family right matters because the exam uses it to separate AI-platform answers from security answers
+- Screens LLM prompts and responses for prompt injection and jailbreak attempts, malicious URLs, sensitive data leakage (via Sensitive Data Protection) and harmful content
+- Two modes: **inspect only** (log the violation, let the request through) and **inspect and block** (log and stop it)
+- Configured through **templates** (filters and confidence thresholds) with org-level **floor settings** that templates cannot weaken
+- Model-agnostic: it sits in front of the model rather than inside it
 
 **Sensitive Data Protection for AI:**
 - Inspect training data for PII before model training
@@ -672,12 +745,13 @@ gcloud artifacts docker images scan us-central1-docker.pkg.dev/my-project/my-rep
 - Audit logging for model access and predictions
 
 **Exam tips:**
-- "Filter harmful content from AI responses" → Model Armor
+- "Filter harmful content or prompt injection from AI prompts and responses" → Model Armor, found under Security Command Center
 - "Protect PII in training data" → Sensitive Data Protection
 - "Prevent data exfiltration from Vertex AI" → VPC Service Controls
+- "Enforce a minimum safety bar across every team's AI app" → Model Armor floor settings at the org or folder, not per-template configuration
 - AI security is new on the PCA exam -- expect 1-2 questions
 
-**Docs:** [Model Armor](https://cloud.google.com/vertex-ai/docs/generative-ai/model-armor), [Responsible AI](https://cloud.google.com/responsible-ai)
+**Docs:** [Model Armor](https://cloud.google.com/security-command-center/docs/model-armor-overview), [Model Armor floor settings](https://cloud.google.com/security-command-center/docs/model_armor_floor_settings), [Responsible AI](https://cloud.google.com/responsible-ai)
 
 ---
 
@@ -807,16 +881,22 @@ gcloud alpha dlp text redact --content="My SSN is 123-45-6789" \
 | CSA STAR | Cloud Security Alliance | Cloud security assessment |
 
 **Accessing compliance reports:**
-- Compliance Reports Manager in Cloud Console
-- Artifact Hub (download SOC reports, ISO certificates)
-- Google Cloud trust center: cloud.google.com/security/compliance
+
+| Surface | What you get |
+|---------|-------------|
+| **Compliance Reports Manager** | On-demand download of Google's own attestations: SOC 1/2/3 reports, ISO/IEC certificates, self-assessments. Free |
+| **Audit Manager** | Runs a compliance audit against **your** environment for a chosen framework and generates the evidence report. Also the console path for downloading Google's compliance documents |
+| **Compliance Manager** (Security Command Center) | Continuous framework-based posture assessment and audit across the resource hierarchy |
+
+The distinction the exam cares about: Compliance Reports Manager proves **Google** is compliant, Audit Manager produces evidence that **your workload** is.
 
 **Exam tips:**
 - "US federal government workload" → FedRAMP certified services + Assured Workloads
-- "Financial audit requirements" → SOC 2 Type II report
+- "Financial audit requirements" → SOC 2 Type II report, downloaded from Compliance Reports Manager
+- "Auditor wants evidence our own environment meets the control set" → Audit Manager, not Compliance Reports Manager
 - Google Cloud compliance does NOT automatically make YOUR application compliant -- shared responsibility
 
-**Docs:** [Compliance Offerings](https://cloud.google.com/security/compliance/offerings)
+**Docs:** [Compliance Offerings](https://cloud.google.com/security/compliance/offerings), [Compliance Reports Manager](https://cloud.google.com/security/compliance/compliance-reports-manager), [Audit Manager](https://cloud.google.com/audit-manager/docs/download_compliance_documents), [Compliance Manager](https://cloud.google.com/security-command-center/docs/compliance-manager-overview)
 
 ---
 
@@ -849,7 +929,7 @@ gcloud logging sinks create audit-sink \
 
 **Access Transparency:**
 - Shows logs of Google personnel accessing your data (customer support, engineering)
-- Available with Premium or Enterprise support
+- Requires a Cloud Customer Care tier of **Standard, Enhanced or Premium**. Basic does not qualify, and "Enterprise" is not a Care tier at all
 - Read-only -- you can see but not block
 
 **Access Approval:**

--- a/gcp/pca/docs/04-optimizing-processes.md
+++ b/gcp/pca/docs/04-optimizing-processes.md
@@ -24,12 +24,14 @@ The PCA exam expects you to understand how cloud-native development workflows op
 ```
 Local Dev
   → Cloud Workstations (managed dev environment)
-    → Push to Source Repository (Cloud Source Repos / GitHub / GitLab)
+    → Push to Source Repository (GitHub / GitLab / Secure Source Manager)
       → Cloud Build (CI: build, test, scan)
         → Artifact Registry (store images, packages)
           → Cloud Deploy (CD: promote through environments)
             → Target (GKE / Cloud Run / GCE)
 ```
+
+> **Naming trap:** **Cloud Source Repositories** has been closed to new customers since 2024-06-17. An organization that never used it cannot enable the API. Google's managed source host for new work is [Secure Source Manager](https://cloud.google.com/secure-source-manager/docs/overview). Treat "Cloud Source Repositories" in an option as a signal the option was written against an older exam guide, unless the scenario explicitly describes an existing deployment.
 
 **Cloud Workstations**
 
@@ -299,11 +301,11 @@ steps:
 
 **Exam tips:**
 - Cloud Build steps run sequentially by default. Use `waitFor: ['-']` to run a step in parallel (it waits for nothing). Use `waitFor: ['step-id']` to create custom dependency chains.
-- The default service account for Cloud Build is `{PROJECT_NUMBER}@cloudbuild.gserviceaccount.com`. For least privilege, create a custom service account and assign it to the trigger.
+- Which service account Cloud Build defaults to depends on when the project first built. Projects created after the mid-2024 change use the **Compute Engine default service account** (`PROJECT_NUMBER-compute@developer.gserviceaccount.com`); older projects keep the legacy Cloud Build service account (`PROJECT_NUMBER@cloudbuild.gserviceaccount.com`). Neither is a good answer -- both are over-privileged. For least privilege, create a dedicated service account and assign it to the trigger.
 - `$PROJECT_ID`, `$COMMIT_SHA`, `$SHORT_SHA`, `$BRANCH_NAME`, `$TAG_NAME`, `$REPO_NAME`, and `$BUILD_ID` are built-in substitutions. Custom substitutions start with `_` (underscore).
 - Private pools are the answer when a question says "build needs to access resources in a private VPC" or "build must not use public internet."
 - `gcloud builds submit` is for ad-hoc builds. Triggers automate builds on source events.
-- The `images` field at the top level of cloudbuild.yaml stores images in Cloud Build's built-in storage (shows in Build History). It does NOT push to a registry -- you still need a `docker push` step.
+- The `images` field at the top level of cloudbuild.yaml **is** the push: Cloud Build pushes the listed images to Artifact Registry after all steps succeed. An explicit `docker push` step is one way to do it, `images` is the other, and using both is merely redundant. Two consequences the exam can turn into a question: an image built during the run but not listed in `images` is **discarded** when the build finishes, and listing an image the build never produced **fails** the build.
 
 **Docs:**
 - [Cloud Build Overview](https://cloud.google.com/build/docs/overview)
@@ -411,7 +413,8 @@ gcloud container binauthz attestations sign-and-create \
 ```
 
 **Exam tips:**
-- Artifact Registry replaces Container Registry (gcr.io). If a question mentions gcr.io, the modern answer is Artifact Registry unless the question specifically says "existing gcr.io setup."
+- Artifact Registry replaces Container Registry. Container Registry is shut down, not deprecated: writes stopped 2025-03-18, reads 2025-06-03. Your own images belong at `REGION-docker.pkg.dev/PROJECT/REPO/IMAGE`.
+- **Not every `gcr.io` URL is stale.** Google-owned images such as the Cloud Build builders (`gcr.io/cloud-builders/docker`, `gcr.io/cloud-builders/gcloud`) keep their `gcr.io` addresses and are served from Artifact Registry. The shutdown applies to customer registries, so leave builder-image references alone.
 - Remote repositories are the answer for "reduce dependency on external registries" or "cache public packages inside your organization."
 - Virtual repositories are the answer for "developers need a single endpoint to pull from multiple repositories."
 - Binary Authorization + Artifact Registry is the answer for "ensure only scanned and signed images are deployed."
@@ -427,7 +430,7 @@ gcloud container binauthz attestations sign-and-create \
 
 #### Cloud Deploy
 
-Cloud Deploy is a managed continuous delivery service that handles progressive delivery to GKE, Cloud Run, and GKE Enterprise (Anthos).
+Cloud Deploy is a managed continuous delivery service that handles progressive delivery to GKE, Cloud Run, and GKE Enterprise (the product formerly marketed as Anthos).
 
 **Core Concepts:**
 - **Delivery Pipeline:** Defines the sequence of targets (environments) a release passes through.
@@ -537,11 +540,11 @@ gcloud deploy releases list \
   --delivery-pipeline=my-app-pipeline \
   --region=us-central1
 
-# Rollback: create a new release from a previous known-good version
-gcloud deploy releases create rollback-001 \
+# Roll a target back. Cloud Deploy creates a new rollout from the last known-good
+# release on that target; --release and --rollout-id pick a different one.
+gcloud deploy targets rollback prod \
   --delivery-pipeline=my-app-pipeline \
-  --region=us-central1 \
-  --images=my-app=us-central1-docker.pkg.dev/my-project/my-repo/my-app:v0.9
+  --region=us-central1
 
 # Check rollout status
 gcloud deploy rollouts list \
@@ -578,7 +581,7 @@ strategy:
 
 The typical end-to-end pipeline:
 
-1. Developer pushes code to GitHub/Cloud Source Repos
+1. Developer pushes code to GitHub, GitLab or Secure Source Manager
 2. Cloud Build trigger fires, runs tests, builds container image
 3. Cloud Build pushes image to Artifact Registry
 4. Cloud Build creates a Cloud Deploy release
@@ -665,8 +668,9 @@ jobs:
 **Exam tips:**
 - Cloud Deploy is for CD only -- it does not build or test. Cloud Build handles CI. This is a common distractor.
 - `requireApproval: true` on a target means a human must approve before rollout proceeds. This is tested in "separation of duties" scenarios.
-- Rollback in Cloud Deploy means creating a new release with the previous image, not "undoing" a rollout.
-- Canary deployments in Cloud Deploy require service mesh (Anthos Service Mesh) or Gateway API for GKE. For Cloud Run, traffic splitting is native.
+- Cloud Deploy has **native rollback**: `gcloud deploy targets rollback TARGET --delivery-pipeline=PIPELINE`. It creates a fresh rollout from the last known-good release on that target. Hand-rolling a new release from the old image is the manual fallback, not the mechanism.
+- Rollback can also be **automated** via a `repairRolloutRule` automation: it retries the failed rollout, and if the retries are exhausted or none are configured it rolls back to the most recent successful release. The other automation rules are `promoteReleaseRule`, `timedPromoteRule` and `advanceRolloutRule`.
+- GKE canary in Cloud Deploy does **not** require a service mesh. `serviceNetworking` uses plain Kubernetes Service selectors and splits by pod count; `gatewayServiceMesh` via the Gateway API is what you pick when you need true traffic-percentage splitting. For Cloud Run, traffic splitting is native.
 - When the exam says "managed progressive delivery service," the answer is Cloud Deploy, not Spinnaker or Jenkins.
 - Workload Identity Federation is the recommended way to authenticate from external CI/CD (GitHub Actions, GitLab CI). Never use exported service account keys.
 
@@ -674,6 +678,9 @@ jobs:
 - [Cloud Deploy Overview](https://cloud.google.com/deploy/docs/overview)
 - [Delivery Pipeline Configuration](https://cloud.google.com/deploy/docs/config-files)
 - [Deployment Strategies](https://cloud.google.com/deploy/docs/deployment-strategies)
+- [Roll back a target](https://cloud.google.com/deploy/docs/roll-back)
+- [Automate your deployment](https://cloud.google.com/deploy/docs/automation)
+- [Canary on GKE with service networking](https://cloud.google.com/deploy/docs/deployment-strategies/canary/gke/service-networking)
 - [Cloud Build + Cloud Deploy](https://cloud.google.com/deploy/docs/integrating-ci)
 
 ---
@@ -691,7 +698,8 @@ The exam tests your ability to choose the right observability tool for a given d
 | **Cloud Trace** | Distributed tracing for request latency | Diagnosing slow requests across microservices |
 | **Error Reporting** | Aggregates and deduplicates errors | Finding top errors, tracking error rates over time |
 | **Cloud Profiler** | Continuous CPU/memory profiling in production | Identifying performance bottlenecks, memory leaks |
-| **Cloud Debugger** (deprecated) | Now replaced by Snapshot Debugger | Inspect application state without stopping it |
+
+> **Retired, and therefore a distractor:** Cloud Debugger was shut down on 2023-05-31, and its open-source successor Snapshot Debugger was archived on 2023-09-07. Neither is a live product. Production state inspection is now a logging and tracing problem: structured logs, Cloud Trace spans, and Cloud Profiler.
 
 **Systematic Debugging Approach:**
 
@@ -710,11 +718,11 @@ gcloud logging metrics create error-count \
   --description="Count of application errors" \
   --log-filter='severity>=ERROR AND resource.type="k8s_container"'
 
-# Create a distribution metric (extracts numeric values)
+# Distribution metrics cannot be defined with flags. The flag form only accepts
+# --description and --log-filter; anything with a value extractor, bucket options
+# or user-defined labels goes through a config file.
 gcloud logging metrics create response-latency \
-  --description="API response latency" \
-  --log-filter='resource.type="cloud_run_revision" AND httpRequest.latency!=""' \
-  --bucket-options=exponential=8,1.5,0.1
+  --config-from-file=response-latency.yaml
 ```
 
 **Log Sinks (Routing):**
@@ -746,7 +754,7 @@ Key concepts:
 - **Trace context propagation:** Headers (`traceparent` for W3C, `X-Cloud-Trace-Context` for Google) must be forwarded between services.
 
 For GKE microservices, enable tracing via:
-- Managed service mesh (Anthos Service Mesh / Istio) for automatic tracing
+- Managed service mesh (Cloud Service Mesh, which absorbed Anthos Service Mesh and Traffic Director) for automatic tracing
 - OpenTelemetry SDK for application-level instrumentation
 - Cloud Trace API for direct integration
 
@@ -786,20 +794,17 @@ The PCA exam tests whether you know the types of testing and which GCP services 
 | **Unit Tests** | Individual functions/methods | Run in Cloud Build steps |
 | **Integration Tests** | Service-to-service interactions | Cloud Build + test environment |
 | **End-to-End (E2E) Tests** | Full user workflows | Cloud Build + test deployment |
-| **Load/Performance Tests** | System behavior under load | Cloud Load Testing, Locust on GKE |
+| **Load/Performance Tests** | System behavior under load | Distributed load testing on GKE (Locust, k6, JMeter) |
 | **Security Scanning** | Vulnerabilities in images and code | Artifact Analysis, Web Security Scanner |
-| **Chaos Engineering** | System resilience to failures | Fault injection in ASM, Gremlin |
+| **Chaos Engineering** | System resilience to failures | Fault injection in Cloud Service Mesh, Gremlin |
 | **Infrastructure Validation** | IaC correctness | `terraform validate`, `terraform plan`, Sentinel/OPA |
 
 **Load Testing:**
 
-Cloud Load Testing (based on open-source Locust) allows you to simulate traffic against your services.
+> **There is no Google Cloud product called "Cloud Load Testing."** Google's answer to load testing is a reference architecture, not a service: [Distributed load testing using GKE](https://cloud.google.com/architecture/distributed-load-testing-using-gke), which runs an open-source generator (Locust in the guide; k6 and JMeter follow the same shape) as a master-and-workers deployment on a GKE cluster you size to the load you need. An option naming a managed Google load-testing service is fabricated.
 
 ```bash
-# Deploy a Locust-based load test on GKE
-# (Cloud Load Testing is integrated into Cloud Console)
-
-# Alternative: use Cloud Build to run load tests
+# Run the load generator from a Cloud Build step against a deployed service
 # cloudbuild.yaml step:
 steps:
   - name: 'python:3.11'
@@ -818,7 +823,7 @@ steps:
 
 Chaos engineering on GCP involves deliberately introducing failures to test resilience:
 
-- **Fault injection with Anthos Service Mesh (ASM):** Inject delays and aborts at the mesh level.
+- **Fault injection with Cloud Service Mesh:** Inject delays and aborts at the mesh level.
 - **Network disruption:** Use VPC firewall rules to simulate network partitions.
 - **Instance termination:** Delete instances to test auto-healing in MIGs.
 - **Zone failure simulation:** Drain a zone's instances to test multi-zone resilience.
@@ -867,8 +872,8 @@ spec:
 - `terraform plan` output should be reviewed before `terraform apply` -- this is a governance control.
 
 **Docs:**
-- [Cloud Load Testing](https://cloud.google.com/load-testing/docs)
-- [GKE Policy Controller](https://cloud.google.com/anthos-config-management/docs/concepts/policy-controller)
+- [Distributed load testing using GKE](https://cloud.google.com/architecture/distributed-load-testing-using-gke)
+- [GKE Policy Controller](https://cloud.google.com/kubernetes-engine/enterprise/policy-controller/docs/overview)
 - [Web Security Scanner](https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview)
 
 ---
@@ -877,13 +882,13 @@ spec:
 
 Service Catalog enables organizations to create curated, pre-approved solutions that teams can self-service deploy.
 
-**Private Catalog (Google Cloud Service Catalog)**
+**Service Catalog (renamed from Private Catalog in 2022)**
 
-Private Catalog allows platform teams to publish Terraform modules, Deployment Manager templates, or solution packages that other teams can discover and deploy through a controlled interface.
+Service Catalog lets platform teams publish curated solutions that other teams in the organization can discover and deploy through a controlled interface.
 
 **Key Concepts:**
-- **Catalog:** A collection of solutions shared with specific GCP projects or folders.
-- **Solution:** A deployable package (Terraform module, container image, Deployment Manager template).
+- **Catalog:** A collection of solutions created under the organization and shared with specific projects or folders.
+- **Solution:** A deployable package. The supported types are **Terraform configurations** and **reference links** to verified external content. Deployment Manager templates were the original type, but Deployment Manager reached end of support on 2026-03-31 and new users have been blocked since 2026-06-30, so **Terraform is the only live authoring path**. [Infrastructure Manager](https://cloud.google.com/infrastructure-manager/docs/overview) is Google's named replacement for Deployment Manager.
 - **Version:** Each solution can have multiple versions for controlled rollouts.
 
 ```bash
@@ -895,7 +900,7 @@ Private Catalog allows platform teams to publish Terraform modules, Deployment M
 gcloud privatecatalog products search --query="web application"
 ```
 
-**Terraform Modules as Service Catalog Entries:**
+**Terraform Configurations as Service Catalog Entries:**
 
 Platform teams create standardized Terraform modules that enforce organizational standards:
 
@@ -930,12 +935,15 @@ module "standard_gke" {
 ```
 
 **Exam tips:**
-- Private Catalog is the answer when the scenario asks for "self-service deployment of standardized solutions" or "curated catalog of approved architectures."
-- The exam tests that you understand the difference between Private Catalog (curated, approved solutions) and Marketplace (third-party or Google solutions).
-- Terraform modules in a centralized repository are a common pattern for standardization without Private Catalog.
+- Service Catalog is the answer when the scenario asks for "self-service deployment of standardized solutions" or "curated catalog of approved architectures." The exam guide and older material may still call it Private Catalog -- same product.
+- The exam tests that you understand the difference between Service Catalog (internal, curated, approved by your own platform team) and Marketplace (third-party or Google solutions).
+- Terraform modules in a centralized repository are a common pattern for standardization without Service Catalog.
+- Any option that proposes publishing **Deployment Manager** templates is dated. Deployment Manager is past end of support; Infrastructure Manager (managed Terraform) is the successor.
 
 **Docs:**
-- [Private Catalog](https://cloud.google.com/private-catalog/docs)
+- [Service Catalog](https://cloud.google.com/service-catalog/docs)
+- [Infrastructure Manager](https://cloud.google.com/infrastructure-manager/docs/overview)
+- [Deployment Manager deprecation](https://cloud.google.com/deployment-manager/docs/deprecations)
 - [Terraform Google Modules](https://registry.terraform.io/namespaces/terraform-google-modules)
 
 ---
@@ -966,7 +974,7 @@ DR is one of the most frequently tested topics in this section. You must be able
 | Service | DR Strategy | Implementation |
 |---------|-------------|----------------|
 | **Compute Engine** | Machine images, snapshots | Schedule snapshots cross-region; use instance templates + MIG for fast recovery |
-| **GKE** | Multi-cluster, backup/restore | GKE Backup for cluster state; Anthos for multi-cluster management |
+| **GKE** | Multi-cluster, backup/restore | Backup for GKE for cluster state; GKE Enterprise fleets for multi-cluster management |
 | **Cloud Run** | Multi-region deployment | Deploy to multiple regions behind Global LB; traffic auto-failover |
 
 ```bash
@@ -1008,8 +1016,9 @@ gcloud container backup-restore backup-plans create my-backup-plan \
 | **Cloud Spanner** | Multi-region config (built-in) | Zero (sync replication) | `nam-eur-asia1`, `nam6`, `eur6` configs are inherently DR-ready |
 | **Firestore** | Multi-region location | Zero (sync replication within location) | Choose `nam5` or `eur3` for multi-region |
 | **Bigtable** | Cross-region replication | Minutes (async) | Add a cluster in DR region; automatic failover with app profiles |
-| **AlloyDB** | Cross-region replication | Minutes (async) | Cross-region replicas for DR |
-| **Memorystore (Redis)** | Cross-region replication | Minutes | Standard tier with replicas |
+| **AlloyDB** | Cross-region replication | Minutes (async) | Up to five secondary clusters in other regions; promote for DR, or switchover with zero data loss for a planned move |
+| **Memorystore for Redis** (non-cluster) | Cross-**zone** replication only | Seconds within the region | Standard tier places replicas in other zones of the same region. It is HA, not DR |
+| **Memorystore for Redis Cluster / Valkey** | Cross-region replication | Minutes (async) | Secondary clusters in another region, with switchover. This is the cross-region answer |
 
 ```bash
 # Cloud SQL: Create a cross-region read replica
@@ -1098,10 +1107,14 @@ A managed backup and disaster recovery service that provides:
 - Spanner multi-region is the most expensive DR solution but provides the strongest guarantees (zero RPO, automatic failover).
 - **Trap:** "Cold standby" does NOT mean infrastructure is running. It means data is replicated and infrastructure is defined (e.g., in Terraform) but not provisioned.
 - Machine images capture everything (boot disk, additional disks, machine config, metadata). Snapshots capture only disk data. For DR, machine images are more complete.
-- GKE Backup for GKE is the managed solution for backing up Kubernetes workloads (namespaces, PVs, cluster configuration).
+- Backup for GKE is the managed solution for backing up Kubernetes workloads (namespaces, PVs, cluster configuration).
+- **Memorystore trap:** Standard tier on Memorystore for Redis replicates across **zones**, not regions. If a scenario needs a cache available after a regional outage, the answer is Memorystore for Redis Cluster or Valkey with a secondary cluster, or rebuilding the cache from the source of truth.
+- AlloyDB is not single-region. It supports cross-region secondary clusters, promotion for DR and zero-data-loss switchover -- do not eliminate it on a cross-region requirement.
 
 **Docs:**
 - [DR Planning Guide](https://cloud.google.com/architecture/dr-scenarios-planning-guide)
+- [Memorystore cross-region replication](https://cloud.google.com/memorystore/docs/cluster/about-cross-region-replication)
+- [AlloyDB cross-region replication](https://cloud.google.com/alloydb/docs/cross-region-replication/about-cross-region-replication)
 - [DR for Data](https://cloud.google.com/architecture/dr-scenarios-for-data)
 - [DR for Applications](https://cloud.google.com/architecture/dr-scenarios-for-applications)
 - [Cloud SQL HA and DR](https://cloud.google.com/sql/docs/mysql/high-availability)
@@ -1255,38 +1268,25 @@ Architects must make and document decisions in a structured, defensible way.
 
 ADRs document the context, decision, and consequences of significant architecture choices. They create a history of why decisions were made.
 
-**ADR Template:**
+**ADR structure:**
 
-```markdown
-# ADR-001: Use Cloud Spanner for Global Transaction Processing
+| Section | What it holds |
+|---------|--------------|
+| **Title** | The decision as a statement, numbered for reference |
+| **Status** | Proposed, Accepted, or Superseded by a later ADR. A reversed decision creates a new ADR rather than editing the old one |
+| **Context** | The forces in play: requirements, constraints, what the current design cannot do |
+| **Decision** | The choice made, stated in one or two sentences |
+| **Consequences** | What this buys, and what it costs. The negative half is the part that earns the document its keep |
+| **Alternatives considered** | Each option and the specific reason it lost |
 
-## Status
-Accepted
+**Worked example, ADR-001 "Use Cloud Spanner for global transaction processing":**
 
-## Context
-Our application requires globally consistent transactions with <10ms read latency.
-Current PostgreSQL deployment cannot scale beyond a single region.
-We need multi-region active-active with zero RPO.
-
-## Decision
-Use Cloud Spanner with multi-region configuration (nam-eur-asia1).
-
-## Consequences
-### Positive
-- Zero RPO, automatic failover
-- Global consistency without application-level conflict resolution
-- Scales horizontally without manual sharding
-
-### Negative
-- Higher cost than Cloud SQL (~10x for equivalent compute)
-- Requires schema design changes (interleaved tables, UUID keys)
-- Team needs Spanner-specific training
-
-## Alternatives Considered
-- CockroachDB on GKE: More control, but operational burden
-- Cloud SQL with cross-region replicas: Lower cost, but eventual consistency
-- AlloyDB: PostgreSQL compatible, but single-region only
-```
+- **Status:** Accepted
+- **Context:** Globally consistent transactions with sub-10ms reads. The current PostgreSQL deployment cannot scale past one region. Multi-region active-active with zero RPO is required.
+- **Decision:** Cloud Spanner in a multi-region configuration.
+- **Consequences, positive:** zero RPO with automatic failover; global consistency without application-level conflict resolution; horizontal scale without manual sharding.
+- **Consequences, negative:** materially higher cost than Cloud SQL; schema design changes (interleaved tables, key choice to avoid hotspotting); the team needs Spanner-specific training.
+- **Alternatives considered:** CockroachDB on GKE, rejected for operational burden. Cloud SQL with cross-region read replicas, rejected because failover is a manual promotion with an async RPO. AlloyDB, rejected because the requirement is synchronous multi-region writes, which its cross-region secondary clusters do not provide -- note that AlloyDB **is** cross-region capable, so "single-region only" would be the wrong reason to reject it.
 
 **Build vs Buy Analysis:**
 
@@ -1323,7 +1323,24 @@ The architect's role is to present these trade-offs clearly to stakeholders, not
 
 ### Customer Success Management
 
-Architects ensure that deployed solutions continue to meet customer and business needs.
+Architects ensure that deployed solutions continue to meet customer and business needs. Two levers show up in exam scenarios: the SLOs you define for your own users, and the Google support relationship you buy underneath them.
+
+**Cloud Customer Care tiers:**
+
+A surprising number of "customer success" and "operational readiness" items resolve to picking a support tier, so know the four and what separates them.
+
+| Tier | Technical support cases | Response target | Signature feature |
+|------|------------------------|-----------------|-------------------|
+| **Basic** | None. Docs, community, billing support and Active Assist only | n/a | Included free with every account |
+| **Standard** | Unlimited 1:1 technical support | P2 first meaningful response within 4 hours | Cloud Support API. Aimed at workloads still in development |
+| **Enhanced** | Unlimited 1:1 technical support | P1 first meaningful response within 1 hour | Third-party technology support; Technical Account Advisor available as an add-on. The usual floor for production |
+| **Premium** | Unlimited 1:1 technical support | P1 first meaningful response within 15 minutes | Assigned **Technical Account Manager** and Customer Aware Support; Mission Critical Services available as an add-on |
+
+Reading the tiers on the exam:
+- "Production workload, needs a committed response time on outages" → Enhanced at minimum. Basic is disqualified because it carries no technical support cases at all.
+- "Named Google contact who knows our architecture", "TAM", "quarterly business reviews" → Premium. The TAM is the discriminator, not the response time.
+- "Fastest possible response on a P1" → Premium, 15 minutes.
+- Support tier is also a **feature gate**, not only a response-time purchase: Access Transparency requires Standard, Enhanced or Premium (see `docs/03`, Audits and Logs). "Enterprise" is not a Care tier name.
 
 **Monitoring Customer-Facing SLOs:**
 
@@ -1345,13 +1362,11 @@ gcloud monitoring uptime create my-check \
   --http-check='{"path":"/health","port":443,"use_ssl":true}' \
   --period=60s
 
-# Create an alerting policy
+# Create an alerting policy. The policy body comes from a file (or an inline
+# --policy string); there is no --condition-threshold-value flag. Thresholds are
+# expressed with --if, e.g. --if='> 0.01'.
 gcloud monitoring policies create \
-  --display-name="High Error Rate" \
-  --condition-display-name="Error rate > 1%" \
-  --condition-filter='metric.type="run.googleapis.com/request_count" AND metric.labels.response_code_class="5xx"' \
-  --condition-threshold-value=0.01 \
-  --notification-channels=projects/my-project/notificationChannels/123
+  --policy-from-file=high-error-rate.yaml
 ```
 
 **Feedback Loops:**
@@ -1365,8 +1380,11 @@ gcloud monitoring policies create \
 - SLOs should measure user experience, not just infrastructure metrics. "Server CPU < 80%" is not an SLO; "99.9% of requests complete in < 200ms" is.
 - Error budgets link reliability to feature velocity: if the error budget is healthy, ship features faster; if exhausted, focus on reliability.
 - Blameless postmortems are a Google SRE principle frequently tested on the PCA exam.
+- Read "customer success" scenarios twice: some are SLO questions, some are support-tier questions. A stem about response commitments, a named Google contact, or third-party technology support is asking you to pick a Customer Care tier, not to design an alert.
 
 **Docs:**
+- [Cloud Customer Care](https://cloud.google.com/support)
+- [Standard Support](https://cloud.google.com/support/docs/standard), [Enhanced Support](https://cloud.google.com/support/docs/enhanced), [Premium Support](https://cloud.google.com/support/docs/premium)
 - [SLO Monitoring](https://cloud.google.com/monitoring/slo)
 - [Alerting Policies](https://cloud.google.com/monitoring/alerts)
 - [Incident Response](https://sre.google/sre-book/managing-incidents/)
@@ -1818,8 +1836,10 @@ BIA is the process of identifying critical business functions and quantifying th
 | **Recommender** | Cost Optimization | Right-sizing, idle resource detection |
 | **Active Assist** | Cost Optimization | Unified recommendation platform |
 | **Cloud Billing** | Cost Optimization | Budgets, alerts, exports |
-| **GKE Backup** | DR | Kubernetes workload backup/restore |
+| **Backup for GKE** | DR | Kubernetes workload backup/restore |
 | **Backup and DR** | DR | Managed backup for Compute, GKE, Cloud SQL |
+| **Service Catalog** | Governance | Curated, self-service internal solutions (Terraform configurations, reference links) |
+| **Cloud Customer Care** | Business process | Support tiers: Basic, Standard, Enhanced, Premium |
 
 ---
 


### PR DESCRIPTION
## Summary

Errata for `docs/03-security-and-compliance.md` and `docs/04-optimizing-processes.md`. Part of a five-lane sweep clearing the backlog in `.claude/state/research/2026-08-09-pca-content-audit.md`.

## The worst one

`04:305` stated, **as an exam tip**, that the `images` field in `cloudbuild.yaml` does *not* push to a registry and that you still need a separate `docker push` step. It does exactly the opposite: `images` **is** the push.

Rewritten with the two consequences the exam can turn into a question: an image built during the run but not listed in `images` is discarded, and listing an image the build never produced fails the build.

## Other fabrications removed

- **"Cloud Load Testing"**, a Google product that has never existed, appeared in three places with a doc link that does not resolve. Rather than delete it silently, the file now warns that no managed Google load-testing service exists, so an option naming one is a fabricated distractor, and points at the real reference architecture.
- `gcloud logging metrics create --bucket-options` (needs `--config-from-file`) and `gcloud monitoring policies create --condition-threshold-value` (needs `--policy-from-file`).

## Facts corrected

Cloud Build default service account depends on project age; Cloud Deploy has native `gcloud deploy targets rollback` plus four automation rules, and its GKE canary needs no service mesh when using `serviceNetworking`; Memorystore Redis Standard is cross-*zone*; AlloyDB supports cross-region replication; Cloud Debugger and Snapshot Debugger are both dead, not one replacing the other; Binary Authorization spans GKE, Cloud Run, Cloud Service Mesh and GDC; SLSA v1.0's Build track stops at L3; Key Access Justifications work on software and HSM keys, not only EKM; Access Transparency needs Standard, Enhanced or Premium support ("Enterprise" is not a Care tier); "Artifact Hub" is a CNCF project, replaced with Compliance Reports Manager and Audit Manager.

## Coverage added

**Confidential Computing**, **Workforce Identity Federation** and **Privileged Access Manager** in doc 03, all absent and all standard PCA answers. **Cloud Customer Care tiers** in doc 04, whose "customer success" section previously read as a second SLO section with no basis for the support-tier questions the exam actually asks.

## A rename deliberately not applied

`gcr.io/cloud-builders/*` paths were left alone. Those are Google-published builder images served from Artifact Registry and explicitly unaffected by the Container Registry shutdown; a blanket rename would have broken working examples. A note records why. Only user-owned image paths move to `REGION-docker.pkg.dev`.

## Corrections to the errata itself

- The SDP built-in detector count was going to be changed from "150+" to "200+". The infoTypes reference publishes no number and tells you to call `infoTypes.list`, so the count was removed rather than swapping one unverifiable figure for another.
- One errata entry claimed the ADR doc link at `04:1323` does not resolve. It does. No change needed.

Customer Care dollar figures were left out here, since the pricing errata is tracked against `docs/06` and belongs to another lane.

## Verification

Zero em dashes added, zero TODO markers.