### PR TITLE
fix(pca): errata sweep for docs 05, 06 and 07

### DIFF
--- a/.claude/state/research/2026-08-09-pca-content-audit.md
+++ b/.claude/state/research/2026-08-09-pca-content-audit.md
@@ -86,22 +86,22 @@ A learner who types these gets "unrecognized". Highest-confusion class of error.
 - [x] `docs/06:634` - `gcloud beta error-events list`. Correct group is `gcloud beta error-reporting events list`.
 - [x] `docs/07:1293` - `gcloud beta carbon-footprint get`. No such group; use the BigQuery export.
 - [x] `docs/10:184-186` - `gcloud ai pipelines runs create`. Fabricated.
-- [ ] `docs/05:2040` - `gcloud services quota update` is alpha-only.
+- [x] `docs/05:2040` - `gcloud services quota update` is alpha-only.
 - [x] `docs/07:831` - org policy `constraints/compute.requireLabels` does not exist. Label governance uses tags or apply-time policy-as-code.
 - [x] `docs/07:361` - `enable-enforce` used on `compute.vmExternalIpAccess`, which is a list constraint needing `set-policy`. The three neighbouring boolean constraints are correct, which makes this harder to spot.
 
 ## P1 - numbers that are wrong
 
 - [x] `docs/07:1026` - Hyperdisk "up to 2.4 TB/s". Off by 1000x. Hyperdisk Balanced maxes at 2,400 MiB/s per volume; Extreme at 5,000 MiB/s; only Hyperdisk ML reaches ~2 TiB/s.
-- [ ] `docs/06:68` - metric retention "5 years". Actual 24 months (6 weeks native, then 10-minute).
-- [ ] `docs/06:72` - log-based metrics "24 months". Actual 6 weeks.
-- [ ] `docs/06:1226` - Enhanced support minimum "$500/month" (actual $100); Premium "contact sales" (published minimum $15,000/month).
-- [ ] `docs/06:2034`, `06:2105` - GKE maintenance exclusion `no_upgrades` "cannot exceed 180 days". Actual 90 days, plus a 48-hours-per-92-day-window rule.
-- [ ] `docs/05:621`, `05:647`, `05:727` - Cloud Shell "resets after 120 min inactivity" / "20 min idle". Actual: session ends after 40 minutes idle, 12-hour session cap, `$HOME` deleted after 120 days.
+- [x] `docs/06:68` - metric retention "5 years". Actual 24 months (6 weeks native, then 10-minute).
+- [x] `docs/06:72` - log-based metrics "24 months". Actual 6 weeks.
+- [x] `docs/06:1226` - Enhanced support minimum "$500/month" (actual $100); Premium "contact sales" (published minimum $15,000/month). Table rebuilt from the per-tier docs pages; Standard's published SLO is P2 within 4 hours in local business hours, and the old P1 rows for Standard were dropped because no P1 SLO is published for that tier.
+- [x] `docs/06:2034`, `06:2105` - GKE maintenance exclusion `no_upgrades` "cannot exceed 180 days". Actual 90 days, plus a 48-hours-per-92-day-window rule.
+- [x] `docs/05:621`, `05:647`, `05:727` - Cloud Shell "resets after 120 min inactivity" / "20 min idle". Actual: session ends after 40 minutes idle, 12-hour session cap, `$HOME` deleted after 120 days. The `e2-small` machine-type claim was also dropped, since the limitations page does not publish a machine type.
 - [ ] `docs/09:118` - Spanner "~$650/mo min". Wrong by 10x. Minimum is 100 processing units; 1000 PU = 1 node.
 - [ ] `docs/01:576` - Spanner "1 node ~ 10,000 reads/sec or 2,000 writes/sec". Current: 22,500 peak reads/sec, 3,500 peak writes/sec (22,500 with throughput-optimized writes).
 - [ ] `docs/02:873` - Bigtable "10K rows/sec reads and writes". Current SSD node: up to 17,000 reads/sec, 14,000 writes/sec.
-- [ ] `docs/07:624` - `nam14` replica list wrong. Actual: read-write in us-east4 (default leader) and northamerica-northeast1, witness in us-east1.
+- [x] `docs/07:624` - `nam14` replica list wrong. Actual: read-write in us-east4 (default leader) and northamerica-northeast1, witness in us-east1. `eur6` added and the two-read-write-plus-witness shape stated explicitly.
 - [x] `docs/07:749`, `07:760` - CUD "20-57%" / "~57% memory-optimized". Actual up to 55% for most series, up to 70% memory-optimized. Flexible CUDs (17-63%) missing entirely.
 - [x] `docs/04:1457-1462` - SUD tier table (~8.3% / ~16.7% / 30%). Published tiers are 0 / 10 / 20 / 30% across quartiles.
 - [x] `docs/04:1453` - "SUDs do not apply to sole-tenant nodes". They do, including the sole-tenancy premium.
@@ -118,16 +118,17 @@ A learner who types these gets "unrecognized". Highest-confusion class of error.
 - [ ] `docs/09:311` - Interconnect 99.9% SLA needs two connections in different edge availability domains, not just one metro.
 - [ ] `docs/09:305`, `09:309`, `09:367` - Dedicated Interconnect "10-200 Gbps". Now 10, 100 and 400 Gbps link types.
 - [ ] `docs/09:322`, `09:329`, `09:369` and `02:22` - HA VPN "3 Gbps per tunnel". Documented limit is 250,000 packets/sec, which is 1-3 Gbps depending on packet size.
-- [ ] `docs/07:858-862` - inter-region egress "$0.01/GB". Within North America it is $0.02/GB.
+- [x] `docs/07:858-862` - inter-region egress "$0.01/GB". Within North America it is $0.02/GB. Confirmed against `cloud.google.com/vpc/pricing-announce`; the whole inter-region table was replaced with the published per-route rates.
 - [x] `docs/07:711` and `02:596` conflict on storage class SLAs. `02:596` is correct (99.9% multi/dual-region, 99.0% regional for the cold classes). `07:711` flattens all three to 99.0% and is wrong.
 - [ ] `docs/01:727` - Dedicated Interconnect "99.9% (1 link)". A single link carries no SLA.
-- [ ] `docs/06:1371` vs `06:668`/`06:1388-1391` - two different downtime bases (43.8 vs 43.2 min). Pick the 30-day basis and make it consistent.
+- [x] `docs/06:1371` vs `06:668`/`06:1388-1391` - two different downtime bases (43.8 vs 43.2 min). Standardised on the 30-day / 43,200-minute basis, with a one-line note that 43.8 comes from a 30.44-day month.
 
 ## P1 - facts that are wrong but not numeric
 
 - [ ] `docs/04:305` - "the `images` field does NOT push to a registry". It does. Stated as an exam tip, which makes it worse.
 - [ ] `docs/04:301` - Cloud Build default SA. New projects default to the Compute Engine default SA, not `{PROJECT_NUMBER}@cloudbuild.gserviceaccount.com`.
 - [ ] `docs/04:788`, `04:795`, `04:869` and `05:270` and `07:660` - "Cloud Load Testing" as a Google product, with a doc link that does not resolve. No such product has ever existed.
+  **Partially done:** `05:270` and `07:660` fixed, both now point at distributed load testing on GKE with Locust or k6 and state explicitly that no Google-managed load testing product exists. The three `docs/04` occurrences belong to another lane, so the box stays open.
 - [ ] `docs/04:539-543`, `04:667` - "Cloud Deploy rollback means creating a new release". Native rollback exists (`gcloud deploy targets rollback`) plus automated rollback rules.
 - [ ] `docs/04:668` - "Cloud Deploy canary requires a service mesh". It supports plain Kubernetes service networking.
 - [ ] `docs/04:693` - Cloud Debugger "replaced by Snapshot Debugger". Both are gone; delete the row.
@@ -139,13 +140,13 @@ A learner who types these gets "unrecognized". Highest-confusion class of error.
 - [ ] `docs/03:620-624` - SLSA "Level 1-4". v1.0 Build track has L1-L3 only.
 - [ ] `docs/03:812` - "Artifact Hub" for compliance reports. Not a Google product. Correct: Compliance Reports Manager, and Audit Manager for evidence generation.
 - [ ] `docs/03:853` - Access Transparency "Premium or Enterprise support". Actual: Standard, Enhanced or Premium. Enterprise is not a Care tier.
-- [ ] `docs/06:325` - "Policy Denied logs can exempt specific users". No principal-exemption mechanism; only a Log Router exclusion filter.
-- [ ] `docs/06:1712` - Web Security Scanner "App Engine and Cloud Run". Actual: App Engine, GKE, Compute Engine. Cloud Run not supported. Contradicts `06:1699` two lines earlier.
-- [ ] `docs/06:1993` - VM Manager metadata key `enable-os-config`. Correct key is `enable-osconfig`.
-- [ ] `docs/05:502` - Datastream destinations include "Cloud SQL (PostgreSQL)". Actual: BigQuery, Cloud Storage, Apache Iceberg.
-- [ ] `docs/05:165` - "Apigee Integrated" tier does not exist. Tiers are Standard, Enterprise, Enterprise Plus, plus pay-as-you-go.
-- [ ] `docs/05:372-397` - the entire Migrate to Containers section is dead. `migctl` and the processing-cluster flow were removed in May 2024.
-- [ ] `docs/05:2271` - decision tree offers "service account with key (or WIF)" for CI/CD. Keys should be a distractor, not a branch. Contradicts `05:2055`.
+- [x] `docs/06:325` - "Policy Denied logs can exempt specific users". No principal-exemption mechanism; only a Log Router exclusion filter.
+- [x] `docs/06:1712` - Web Security Scanner "App Engine and Cloud Run". Actual: App Engine, GKE, Compute Engine. Cloud Run not supported. Contradicts `06:1699` two lines earlier. Managed vs custom scan differences corrected at the same time (managed scans are Premium/Enterprise, weekly, GET-only, default ports only).
+- [x] `docs/06:1993` - VM Manager metadata key `enable-os-config`. Correct key is `enable-osconfig`.
+- [x] `docs/05:502` - Datastream destinations include "Cloud SQL (PostgreSQL)". Actual: BigQuery, Cloud Storage, Apache Iceberg. Source list also refreshed (MongoDB, Spanner, Salesforce, Workday added).
+- [x] `docs/05:165` - "Apigee Integrated" tier does not exist. Tiers are Standard, Enterprise, Enterprise Plus, plus pay-as-you-go. Rebuilt as three tables: pricing model, subscription entitlements, deployment option, with Apigee X named as the old name for the Google-managed deployment rather than a tier.
+- [x] `docs/05:372-397` - the entire Migrate to Containers section is dead. `migctl` and the processing-cluster flow were removed in May 2024. Replaced with the local `m2c` CLI four-step flow (copy, analyze, edit plan, generate) plus `migrate-data`.
+- [x] `docs/05:2271` - decision tree offers "service account with key (or WIF)" for CI/CD. Keys should be a distractor, not a branch. Contradicts `05:2055`. Branch now reads WIF with a repository-scoped attribute condition, plus a separate impersonation branch for humans.
 - [ ] `docs/09:15`, `09:98` - "Autopilot has no DaemonSets" and "need DaemonSets or GPUs, use Standard". Both wrong, stated twice. Autopilot supports both.
 - [ ] `docs/09:148`, `09:200` - "Firestore cannot change mode after creation". An empty database can switch, and both modes can coexist in one project.
 - [ ] `docs/09:141` - "Firestore under 10 TB" as a branch condition. No such documented limit; invented threshold.
@@ -178,23 +179,30 @@ The Vertex AI rebrand is the big one and is a rewrite, not a find-and-replace.
 - [?] **Vertex AI to Gemini Enterprise Agent Platform.** Rebranded at Cloud Next 2026; Vertex AI left the Console 2026-05-21. "Vertex AI Agent Builder" appears as a *correct answer* in `section-1-designing-planning.md:659` and `:1094`, `section-2-provisioning-infrastructure.md:661`, `case-study-questions.md:207`. Model tables reference SKUs that now 404 (`docs/02:2098-2100`, `02:2190`, `01:787`). Affects docs 01, 02, 09.
   **Decision needed:** the v6.1 exam guide (Oct 2025) still uses Vertex AI naming. Recommendation is to keep exam-guide names primary and add a "now marketed as" note, rather than rewriting to names the exam does not use.
 - [ ] **Anthos to GKE Enterprise**, **Anthos Service Mesh + Traffic Director to Cloud Service Mesh**: `docs/01:279`, `01:641`, `01:742`, `01:1043`, `02:425`, `02:1505`, `04:429`, `04:668`, `04:749`, `04:790`, `04:820`, `04:972`, `06:788`, `06:1586`, `06:1660`, `06:1674`, `07:102`, `07:469`, `07:1005`, `07:1388`, `05:115`.
+  **Partially done:** all `docs/05`, `docs/06` and `docs/07` occurrences fixed, including the Config Sync and Config Controller doc URLs, which had moved to the `kubernetes-engine/enterprise/` tree. `docs/01`, `02` and `04` belong to other lanes.
 - [ ] **Container Registry shut down** (writes 2025-03-18, reads 2025-06-03) but `gcr.io` still used in examples: `docs/02:1363`, `02:1370`, `05:297`, `05:301`, `05:305`, `05:1671`, `06:867`, `06:892`, `06:976`, `06:1000`, `07:178`. Also listed as a VPC-SC protectable service at `03:369`.
+  **Partially done:** all image paths in `docs/05`, `06` and `07` now use `REGION-docker.pkg.dev`. Cloud Build *builder* images (`gcr.io/cloud-builders/*`, `gcr.io/google.com/cloudsdktool/cloud-sdk`) were deliberately left alone: those are Google-published builder references that Google's own docs still use, and they are not Container Registry repositories the user owns.
 - [ ] **Cloud Functions to Cloud Run functions**: `docs/01:1018`, `05:169`, `05:216`, `05:238`, `06:622`, `06:641`, `07:562`, `07:977`, `07:803`, `07:1109`, `07:1231`, `questions/section-5-managing-implementations.md:229`, `:531`.
+  **Partially done:** all occurrences in `docs/05`, `06` and `07` renamed. `docs/01` and the question file belong to other lanes.
 - [ ] **Dataproc to Managed Service for Apache Spark**: `docs/09:62-66`, `09:93`, `09:100`, `09:891`, `09:1002`.
 - [ ] **Migrate for Compute Engine to Migrate to Virtual Machines**: `docs/09:835`, `09:889`, `09:903`, `09:1033`, `05:399`, `05:555`. M4CE v4.11 end of support 2024-04-30.
+  **Partially done:** `05:399` heading and `05:555` doc URL fixed (the old link pointed at the dead `migrate/compute-engine/docs` path; it is now `migrate/virtual-machines/docs`), with a line stating that Migration Center is a separate product, not the same lineage. `docs/09` belongs to another lane.
 - [ ] **BeyondCorp Enterprise to Chrome Enterprise Premium**: `questions/section-3-security-compliance.md:749`.
 - [ ] **Cloud Operations Suite to Google Cloud Observability**: `docs/01:414`, `07:222`, `07:1476`.
+  **Partially done:** both `docs/07` occurrences fixed. `docs/01` belongs to another lane.
 - [ ] **Cloud Source Repositories** closed to new customers 2024-06-17, presented as live: `docs/01:180`, `04:28`, `04:580`. Successor is Secure Source Manager.
 - [ ] **Deployment Manager** past end of support 2026-03-31, new users blocked from 2026-06-30: `docs/05:1809-1841`, `09:937-941`, `09:967`, `09:974`, `10:592`, `10:600`, `04:881`.
+  **Partially done:** `docs/05:1809-1841` replaced. The YAML/Jinja2 sample and the three `gcloud deployment-manager` commands are gone, leaving a short block that states the dates and names Infrastructure Manager as the migration path, and the docs link now points at the deprecation notice. `docs/04`, `09` and `10` belong to other lanes.
 - [ ] **Memorystore for Memcached deprecated** (no new instances after 2027-02-01, shutdown 2029-01-31): `docs/09:174`, `09:191`. Memorystore for Valkey missing entirely from the in-memory branch.
 - [ ] **PaLM 2 and Codey retired** April 2025: `docs/02:2156`, `09:634`.
 - [ ] **Model Armor is under Security Command Center**, not Vertex AI: `questions/section-3-security-compliance.md:654`, `docs/03:650-654` (also wrong doc URL).
 - [ ] **Cloud Armor Managed Protection Plus to Cloud Armor Enterprise**: `docs/02:214`.
 - [ ] **Private Catalog to Service Catalog** (renamed March 2022): `docs/04:879`, `04:936-937`.
-- [ ] **Terraform Cloud to HCP Terraform**: `docs/05:1262`.
+- [x] **Terraform Cloud to HCP Terraform**: `docs/05:1262`. Also fixed the two Sentinel references that named Terraform Cloud.
 - [ ] **gsutil to gcloud storage.** gsutil leaves the CLI bundle March 2027. `docs/10:806-825` gives gsutil its own section while `gcloud storage` is absent. Invert the emphasis but keep gsutil, since the exam guide still names it.
 - [ ] Dated version pins that will rot: TPU v3 (`questions/section-1-designing-planning.md:472`), GKE 1.28/1.29 (`section-6:587`), pd-ssd with no Hyperdisk (`section-2:492`), provider `~> 5.0` (`docs/10:285-294`, `05:1122-1129`) against a current 7.x, `POSTGRES_15` (`10:505`), CFT module pins (`10:412`, `10:427`).
-- [ ] `docs/06:1589` - Istio `networking.istio.io/v1alpha3`. Current is `v1` since Istio 1.22.
+  **Partially done:** `05:1122-1129` bumped to `~> 7.0`. Everything else on this line is in other lanes.
+- [x] `docs/06:1589` - Istio `networking.istio.io/v1alpha3`. Current is `v1` since Istio 1.22.
 - [ ] `docs/02:5` claims "Last updated: February 2026", now stale and predating the rebrand. `docs/01` has no last-updated marker.
 
 ## P2 - README and exam-metadata problems
@@ -221,20 +229,23 @@ The Vertex AI rebrand is the big one and is a rewrite, not a find-and-replace.
 
 - [ ] **Google Cloud VMware Engine** - named verbatim in objective 2.3, zero mentions anywhere. Belongs in `docs/02` under 2.3.
 - [ ] **Infrastructure Manager** - Google's managed Terraform and the named Deployment Manager replacement. Absent from `docs/05` and `docs/09` section 10. Biggest single gap given v6.1 made IaC explicit.
+  **Partially done:** added to `docs/05` in the IaC alternatives section (deployments / revisions / previews / resource drift, the three config sources, the nominated service account, the no-`backend`-block and no-`provisioners` constraints), plus the `gcloud infra-manager` commands, the IaC comparison table, the exam tips, the decision tree and the section checklist. Every flag was checked against the `gcloud infra-manager` reference: note `resource-drifts list` takes `--preview`, not `--revision`. `docs/09` belongs to another lane.
 - [ ] **Confidential Computing** - Confidential VMs, Confidential GKE Nodes, Confidential Space. Absent from `docs/03`.
 - [ ] **Workforce Identity Federation** - absent; only Workload Identity Federation is covered (`docs/03:529-560`). The workforce/workload distinction is a classic trap.
 - [ ] **Privileged Access Manager** - the canonical answer for just-in-time elevation and break-glass. Missing from separation of duties (`docs/03:269-303`).
 - [ ] **Cloud NGFW Enterprise** - objective 2.1 names intrusion protection; `docs/02:247-266` covers only Cloud IDS, which is detection-only.
 - [ ] **Network Connectivity Center** - two passing rows (`docs/02:188`, `02:344`), absent from the `docs/09` connectivity tree. Objective 2.1 covers exactly this.
-- [ ] **Metrics scopes** - multi-project observability, arguably the architect-level Cloud Monitoring topic. Absent from `docs/06`.
-- [ ] **SLO composition across dependent services** - the multiplicative rule is a classic PCA calculation, absent.
+- [x] **Metrics scopes** - multi-project observability, arguably the architect-level Cloud Monitoring topic. Absent from `docs/06`. Added under Cloud Monitoring: scope / scoping project / monitored project, the 375-project supported limit against the 3,500 hard limit, and the metrics-scope vs aggregated-sink distinction.
+- [x] **SLO composition across dependent services** - the multiplicative rule is a classic PCA calculation, absent. Added as its own subsection in 6.5, covering serial (multiply availabilities), redundant (multiply unavailabilities), the independence assumption, and working backwards to internal SLO targets.
 - [ ] **DORA metrics** - absent from all files despite Google owning the research and citing it throughout WAF.
+  **Done for `docs/06`:** added in 6.1, using the current five-metric set (deployment frequency, change lead time, change fail rate, deployment rework rate, failed deployment recovery time) with the throughput/stability split. Left open because the other doc files may still want a reference.
 - [ ] **Cloud Customer Care tiers** - `docs/04:1327-1377` "customer success" is effectively a second SLO section. Exam items framed as customer success often resolve to picking a support tier, and there is no basis for that here.
+  **Partially done:** `docs/06` now carries a corrected four-tier Customer Care table (Basic / Standard / Enhanced / Premium) with the published pricing formulas and response SLOs. `docs/04` belongs to another lane.
 - [ ] **Dynamic Workload Scheduler** - objective 2.4's "optimizing for different consumption models" is exactly this. Absent.
 - [ ] **Gemini Enterprise** (objective 2.5: AI Agents and NotebookLM) - NotebookLM gets one row; AI Agents absent.
 - [ ] Missing decision trees in `docs/09`, ranked by expected yield: resource hierarchy / landing zone, network topology selection, data pipeline and ingestion, multi-tenancy isolation, identity and federation, CI/CD topology, AI/ML serving, caching strategy, observability and logging architecture, cost optimization, compliance and data residency, encryption key strategy.
 - [ ] Thin relative to weight: securing AI (`docs/03:648-681`, 33 lines for a named objective), envisioning future improvements (`docs/01:1177-1237`, all of 1.5), success measurements (`docs/01:331-354`), Cloud Code (`docs/05:661-682`).
-- [ ] `docs/06:13-22` and `07:53-65` - the operational excellence "key principles" are hand-written SRE principles, not Google's published pillar principles. Objective 6.1 reads verbatim "the principles and recommendations of the operational excellence pillar", so a question quoting Google's wording would not be recognisable.
+- [x] `docs/06:13-22` and `07:53-65` - the operational excellence "key principles" are hand-written SRE principles, not Google's published pillar principles. Objective 6.1 reads verbatim "the principles and recommendations of the operational excellence pillar", so a question quoting Google's wording would not be recognisable. Both replaced with the five published principles; the SRE material is kept in `docs/06` as an explicitly labelled supporting-concepts table.
 
 ## P2 - effort is allocated inversely to exam weight (verified)
 
@@ -285,9 +296,9 @@ PCA does not test flag recall. These blocks should compress to the decision they
 - [ ] `docs/02:36-81` - 45 lines of HA VPN and BGP peer commands. Keep the topology decision, drop the commands.
 - [ ] `docs/02:396-427` - six-step global external ALB creation sequence. The architect question is which LB and why, already answered at `02:372-394`.
 - [ ] `docs/02:1130-1183`, `02:538-570`, `02:1405-1421`, `02:2051-2066` - instance template/MIG, Cloud DNS, patch deployment, and pre-built AI API command blocks.
-- [ ] `docs/05:750-913` - 160 lines of gcloud/gsutil/bq/cbt/kubectl recall. `cbt` and the kubectl block have no PCA surface at all.
-- [ ] `docs/05:1964-2029`, `05:2088-2157` - hand-rolled pagination loop, manual backoff implementation, 30-line Go GCS function, full Pub/Sub and Secret Manager client code.
-- [ ] `docs/06:860-898`, `06:948-1017`, `06:1057-1075` - Cloud Deploy flags, 70 lines of blue/green YAML, kubectl rollout list.
+- [x] `docs/05:750-913` - 160 lines of gcloud/gsutil/bq/cbt/kubectl recall. `cbt` and the kubectl block have no PCA surface at all. Compressed to a five-row "CLI to surface" table plus the `gsutil` vs `gcloud storage` decision, including the `gcloud storage sign-url --impersonate-service-account` point that removes the downloaded-key problem.
+- [x] `docs/05:1964-2029`, `05:2088-2157` - hand-rolled pagination loop, manual backoff implementation, 30-line Go GCS function, full Pub/Sub and Secret Manager client code. Replaced with a failure-to-response table (including the "never retry a 403 allocation quota" point) and a three-line ADC snippet.
+- [x] `docs/06:860-898`, `06:948-1017`, `06:1057-1075` - Cloud Deploy flags, 70 lines of blue/green YAML, kubectl rollout list. Cut to the four-command lifecycle, the Service-selector switch that is the whole of blue-green, and the rollback-cost argument that decides between the strategies. Native `gcloud deploy targets rollback` and the verify-vs-analysis distinction added while there.
 - [ ] `docs/04:115-297`, `04:331-377`, `04:506-550`, `04:1640-1668` - three near-identical cloudbuild.yaml variants, Artifact Registry CRUD, eleven gcloud deploy commands, label/tag CLI.
 - [ ] `docs/03:190-248`, `03:337-408` - KMS/Secret Manager and access-context-manager syntax.
 - [ ] Too deep for PCA: `docs/02:1941-1948` and `02:2169-2177` (quantization, distillation, pruning, RLHF, soft-prompt tuning - ML Engineer territory), `02:1977-1983` (parallelism strategies), `02:1834-1838` (TPU slice/ICI/DCN internals).
@@ -296,9 +307,9 @@ Keep as the model for rewrites: `docs/07:1392-1441` (pillar trade-off matrix, th
 
 ## P3 - structural defects
 
-- [ ] `docs/06:1166-1187` - the sample runbook is fenced but its internal markdown headings leak into the document outline, appearing as siblings of section 6.4.
+- [x] `docs/06:1166-1187` - the sample runbook is fenced but its internal markdown headings leak into the document outline, appearing as siblings of section 6.4. Fence retagged to `text` and the `##`/`###` lines replaced with plain uppercase labels.
 - [ ] `docs/04:1266-1288` - same problem with the ADR example's headings.
-- [ ] `docs/05:1809-1858` - IaC comparison table omits Infrastructure Manager.
+- [x] `docs/05:1809-1858` - IaC comparison table omits Infrastructure Manager. Table rebuilt with five columns and new "who runs it" and "identity used" rows, which is what actually separates self-run Terraform from Infrastructure Manager.
 - [ ] `gcp/ace/docs/05-access-and-security.md:3` and `:1150` - `[Back to README](./README.md)` links to a file that does not exist; the README is one level up.
 - [ ] **ACE exam weights disagree across four files.** `gcp/ace/README.md:25-28` says Domain 1 ~23%, Domain 2 ~30%; the doc H1s say ~20% and ~17.5% on the older 5-domain scheme. Root `CLAUDE.md` agrees with the README. Question file headers restate it a fourth time.
 - [ ] **Question counts are maintained in five places**: root `CLAUDE.md`, `.claude/domain-reference.md:130-135` and `:36-46`, `.claude/study-modes.md:15-31`, both exam READMEs, and inside each question file. Single source of truth should be the `Total questions: N` line in each question file.

--- a/gcp/pca/docs/05-managing-implementations.md
+++ b/gcp/pca/docs/05-managing-implementations.md
@@ -93,7 +93,7 @@ spec:
   uniformBucketLevelAccess: true
 ```
 
-**Config Sync** -- GitOps tool for GKE. It syncs Kubernetes manifests from a Git repo to your clusters. Pairs with Policy Controller for guardrails.
+**Config Sync** -- GitOps tool for GKE, part of GKE Enterprise (formerly Anthos). It syncs Kubernetes manifests from a Git repo to your clusters. Pairs with Policy Controller for guardrails.
 
 ```bash
 # Enable Config Sync on a GKE fleet membership
@@ -112,7 +112,7 @@ gcloud container fleet config-management status
 > - Rolling updates with `maxUnavailable=0` ensure zero downtime.
 > - Cloud Run traffic splitting is revision-based and instant (no new deployment needed).
 
-**Docs:** [MIG rolling updates](https://cloud.google.com/compute/docs/instance-groups/rolling-out-updates-to-managed-instance-groups) | [Cloud Run traffic management](https://cloud.google.com/run/docs/rollouts-rollbacks-traffic-migration) | [Config Controller](https://cloud.google.com/anthos-config-management/docs/concepts/config-controller-overview) | [Config Sync](https://cloud.google.com/anthos-config-management/docs/config-sync-overview)
+**Docs:** [MIG rolling updates](https://cloud.google.com/compute/docs/instance-groups/rolling-out-updates-to-managed-instance-groups) | [Cloud Run traffic management](https://cloud.google.com/run/docs/rollouts-rollbacks-traffic-migration) | [Config Controller](https://cloud.google.com/kubernetes-engine/enterprise/config-controller/docs/overview) | [Config Sync](https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/overview) | [GKE Enterprise](https://cloud.google.com/kubernetes-engine/enterprise/docs/concepts/overview)
 
 ---
 
@@ -156,17 +156,33 @@ gcloud apigee deployments list \
   --organization=my-org
 ```
 
-**Apigee tiers:**
+**Apigee pricing models.** Two ways to buy, and they are not tiers of each other:
 
-| Tier | Use Case |
-|------|----------|
-| **Apigee X** | Full enterprise, VPC-peered, private networking |
-| **Apigee hybrid** | Control plane on GCP, runtime on-prem or other cloud |
-| **Apigee Integrated** | Pay-as-you-go, simpler setup, good for getting started |
+| Model | How It Bills | Notes |
+|-------|-------------|-------|
+| **Subscription** | Annual commitment, three tiers | Standard, Enterprise, Enterprise Plus |
+| **Pay-as-you-go** | Per API call and per gateway node-hour | No commitment; good for variable or starting workloads |
+
+**Subscription tiers,** by entitlement:
+
+| Tier | Annual Standard Proxy Calls | Active Environments | Proxy Deployment Units | Hybrid Entitlement |
+|------|-----------------------------|---------------------|------------------------|--------------------|
+| **Standard** | Up to 1.25 billion | 3 | 250 | No |
+| **Enterprise** | Up to 7.5 billion | 6 | 500 | Yes |
+| **Enterprise Plus** | Up to 75 billion | 12 | 1,500 | Yes |
+
+Advanced API Security and Monetization are add-ons purchasable on any tier.
+
+**Deployment options** (a separate choice from the pricing model):
+
+| Option | Where the Runtime Lives |
+|--------|-------------------------|
+| **Apigee** (formerly Apigee X) | Google-managed runtime in Google Cloud, VPC-peered or Private Service Connect |
+| **Apigee hybrid** | Management plane in Google Cloud, runtime in your own Kubernetes cluster (on-prem or another cloud) |
 
 #### API Gateway (Serverless, Simpler)
 
-API Gateway is a fully managed, serverless gateway for Cloud Functions, Cloud Run, and App Engine backends. Simpler than Apigee, no developer portal or monetization.
+API Gateway is a fully managed, serverless gateway for Cloud Run, Cloud Run functions, and App Engine backends. Simpler than Apigee, no developer portal or monetization.
 
 ```bash
 # Create an API config from an OpenAPI spec
@@ -213,7 +229,7 @@ gcloud endpoints services describe my-api.endpoints.my-project.cloud.goog
 | **Rate limiting** | Advanced (spike arrest, quotas, per-developer) | Basic (per-gateway) | Basic |
 | **Analytics** | Rich dashboard, custom reports | Cloud Logging/Monitoring | Cloud Logging/Monitoring |
 | **Protocol** | REST, SOAP, GraphQL | REST (OpenAPI) | REST (OpenAPI), gRPC |
-| **Backend** | Any HTTP backend | Cloud Functions, Cloud Run, App Engine | Any (deployed as sidecar) |
+| **Backend** | Any HTTP backend | Cloud Run, Cloud Run functions, App Engine | Any (deployed as sidecar) |
 | **Pricing** | Most expensive (subscription) | Pay-per-call (cheap) | Free (you pay for ESP compute) |
 | **Hybrid/multi-cloud** | Yes (Apigee hybrid) | No | No |
 | **API versioning** | Built-in revision management | Via API configs | Via service configs |
@@ -235,12 +251,13 @@ gcloud endpoints services describe my-api.endpoints.my-project.cloud.goog
 
 > **Exam tips:**
 > - **Apigee** = enterprise, external developers, monetization, developer portal. If the question mentions "third-party developers" or "partner API program," pick Apigee.
-> - **API Gateway** = simplest option for serverless (Cloud Functions / Cloud Run) backends. Pay-per-call.
+> - **API Gateway** = simplest option for serverless (Cloud Run / Cloud Run functions) backends. Pay-per-call.
 > - **Cloud Endpoints** = gRPC support, sidecar proxy (ESP/ESPv2). Free service -- you pay for the compute running the proxy.
 > - If the question mentions "SOAP" or "XML transformation," Apigee is the only option with mediation capabilities.
-> - Apigee hybrid = runtime on-prem, control plane on GCP. Used for regulated industries or multi-cloud.
+> - Apigee hybrid = runtime in your own Kubernetes cluster, management plane on Google Cloud. Used for regulated industries or multi-cloud. Hybrid entitlement comes with Enterprise and Enterprise Plus, not Standard.
+> - Trap: **Apigee X is not a tier**, it is the old name for the Google-managed deployment. Tiers are Standard / Enterprise / Enterprise Plus, and pay-as-you-go is a separate pricing model, not a tier.
 
-**Docs:** [Apigee](https://cloud.google.com/apigee/docs) | [API Gateway](https://cloud.google.com/api-gateway/docs) | [Cloud Endpoints](https://cloud.google.com/endpoints/docs) | [Choosing an API management product](https://cloud.google.com/api-gateway/docs/choose-api-management)
+**Docs:** [Apigee](https://cloud.google.com/apigee/docs) | [Apigee subscription entitlements](https://cloud.google.com/apigee/docs/api-platform/reference/subscription-entitlements) | [Apigee pricing](https://cloud.google.com/apigee/pricing) | [API Gateway](https://cloud.google.com/api-gateway/docs) | [Cloud Endpoints](https://cloud.google.com/endpoints/docs) | [Choosing a Cloud Endpoints option](https://cloud.google.com/endpoints/docs/choose-endpoints-option)
 
 ---
 
@@ -267,8 +284,9 @@ kubectl apply -f locust-worker.yaml
 | **Locust** | Python-based, scriptable | GKE, Compute Engine |
 | **JMeter** | Java-based, GUI + CLI | Compute Engine, Cloud Build |
 | **k6** | JavaScript-based, modern | Cloud Build, Compute Engine |
-| **Cloud Load Testing** (deprecated) | Was GCP-native | Use Locust or k6 instead |
-| **Fortio** | Istio's load testing tool | GKE (especially with Istio) |
+| **Fortio** | Service mesh load testing tool | GKE (especially with Cloud Service Mesh) |
+
+There is no Google-managed load testing product. Google's published pattern is distributed load testing on GKE with Locust or a similar open-source tool. Any option naming a "Cloud Load Testing" service is a distractor.
 
 #### Testing in CI/CD Pipelines (Cloud Build)
 
@@ -292,17 +310,17 @@ steps:
         sleep 5
         PUBSUB_EMULATOR_HOST=localhost:8085 pytest tests/integration/ -v
 
-  # Build container
+  # Build container. Container Registry is shut down -- images go to Artifact Registry.
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/my-app:$COMMIT_SHA', '.']
+    args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/my-repo/my-app:$COMMIT_SHA', '.']
 
   # Push container
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', 'gcr.io/$PROJECT_ID/my-app:$COMMIT_SHA']
+    args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/my-repo/my-app:$COMMIT_SHA']
 
   # Deploy to staging
   - name: 'gcr.io/cloud-builders/gcloud'
-    args: ['run', 'deploy', 'my-app-staging', '--image', 'gcr.io/$PROJECT_ID/my-app:$COMMIT_SHA', '--region', 'us-central1']
+    args: ['run', 'deploy', 'my-app-staging', '--image', 'us-central1-docker.pkg.dev/$PROJECT_ID/my-repo/my-app:$COMMIT_SHA', '--region', 'us-central1']
 
   # Smoke tests against staging
   - name: 'curlimages/curl'
@@ -323,7 +341,7 @@ Contract testing validates that an API provider meets the expectations of its co
 > - Contract testing is the exam-relevant answer when asked "how to test microservice APIs independently."
 > - Canary deployments + automated rollback = the GCP-recommended progressive delivery approach.
 
-**Docs:** [Cloud Build](https://cloud.google.com/build/docs) | [Cloud Build triggers](https://cloud.google.com/build/docs/automating-builds/create-manage-triggers) | [Testing overview](https://cloud.google.com/architecture/devops/devops-tech-test-automation)
+**Docs:** [Cloud Build](https://cloud.google.com/build/docs) | [Cloud Build triggers](https://cloud.google.com/build/docs/automating-builds/create-manage-triggers) | [Distributed load testing using GKE](https://cloud.google.com/architecture/distributed-load-testing-using-gke) | [Testing overview](https://cloud.google.com/architecture/devops/devops-tech-test-automation)
 
 ---
 
@@ -369,45 +387,33 @@ gcloud database-migration migration-jobs promote my-migration \
   --region=us-central1
 ```
 
-#### Migrate to Containers (Migrate for Anthos)
+#### Migrate to Containers
 
 Converts VM-based workloads into containers running on GKE. Useful for modernizing legacy apps without rewriting.
 
-```bash
-# Install Migrate to Containers on a processing cluster
-gcloud container clusters get-credentials my-processing-cluster --zone=us-central1-a
-migctl setup install
+The architecture changed in May 2024. The console UI, `migctl`, and the CRDs that ran migrations through a **processing cluster** were removed. Migrations now run from the **Migrate to Containers CLI** (`m2c`) on a local Linux or Windows machine, and the cluster is only the deployment target.
 
-# Add a migration source (e.g., vSphere, AWS, Azure, or Compute Engine)
-migctl source create my-ce-source --type=compute-engine
+The four-step flow:
 
-# Generate a migration plan
-migctl migration create my-migration --source=my-ce-source --vm-id=my-vm
+| Step | `m2c` Command | What It Produces |
+|------|---------------|------------------|
+| 1. Copy | `m2c copy` | The source VM's file system, pulled locally over gcloud or SSH |
+| 2. Analyze | `m2c analyze` | A modernization plan describing the detected workload |
+| 3. Edit | (edit the plan by hand) | Adjusted container config, volumes, exposed ports |
+| 4. Generate | `m2c generate` | Dockerfile, container image build context, and Kubernetes manifests |
 
-# Review and customize the migration plan
-migctl migration get-plan my-migration > plan.yaml
-# Edit plan.yaml (adjust container config, data volumes, etc.)
-migctl migration update my-migration --plan-file=plan.yaml
+`m2c migrate-data` moves data from the local machine into PersistentVolumeClaims on the connected cluster. Nothing in this flow uses `migctl` any more -- if an option or a command in a question mentions `migctl` or a processing cluster, it is stale.
 
-# Execute the migration (generates container artifacts)
-migctl migration generate-artifacts my-migration
+#### Migrate to VMs
 
-# Deploy generated artifacts to target GKE cluster
-kubectl apply -f deployment_spec.yaml
-```
+Migrate VMs from on-premises (VMware, AWS, Azure) to Compute Engine with minimal downtime. Uses continuous replication. This is the successor to Migrate for Compute Engine (M4CE), whose v4.11 left support on 2024-04-30. Migration Center is a separate product and is not the same lineage.
 
-#### Migrate to VMs (Migrate for Compute Engine)
+Key concepts:
 
-Migrate VMs from on-premises (VMware, AWS, Azure) to Compute Engine with minimal downtime. Uses continuous replication.
-
-```bash
-# Migrate to VMs uses the Google Cloud Console or the Migrate connector
-# Key concepts:
-# - Source: VMware vSphere, AWS EC2, Azure VMs, physical servers
-# - Replication: Continuous block-level replication
-# - Test clone: Create a test VM without disrupting the source
-# - Cutover: Final migration, source VM is shut down
-```
+- **Source:** VMware vSphere, AWS EC2, Azure VMs, physical servers
+- **Replication:** continuous block-level replication while the source keeps running
+- **Test clone:** create a test VM from replicated data without disrupting the source
+- **Cutover:** final migration, source VM is shut down
 
 #### Migration Center (Assessment and Planning)
 
@@ -498,10 +504,12 @@ bq mk --transfer_run --run_time='2026-02-15T00:00:00Z' projects/my-project/locat
 
 Datastream provides serverless change data capture (CDC) and replication. Streams changes from:
 
-- **Sources:** MySQL, PostgreSQL, Oracle, SQL Server
-- **Destinations:** BigQuery, Cloud Storage, Cloud SQL (PostgreSQL)
+- **Sources:** MySQL, PostgreSQL (including AlloyDB), Oracle, SQL Server, MongoDB, Spanner, plus SaaS sources such as Salesforce and Workday
+- **Destinations:** BigQuery, Cloud Storage, Apache Iceberg tables
 
 Use case: real-time replication to BigQuery for analytics.
+
+Exam trap: **Cloud SQL and Spanner are not Datastream destinations.** Reaching them means landing in Cloud Storage and using a Dataflow template to load onward.
 
 ```bash
 # Create a Datastream connection profile
@@ -549,10 +557,10 @@ gcloud datastream streams create my-stream \
 > - **Storage Transfer Service** = cloud-to-cloud or on-prem-to-GCS file transfers. NOT for database migration.
 > - **BigQuery Data Transfer Service** = scheduled data loading INTO BigQuery from external sources. Not for real-time.
 > - **Migration Center** = assessment and planning ONLY. It does not perform the actual migration.
-> - **Migrate to Containers** generates Docker artifacts from VMs -- it does NOT require code changes.
+> - **Migrate to Containers** generates Docker artifacts from VMs -- it does NOT require code changes. Runs from the local `m2c` CLI, not `migctl`.
 > - **Transfer Appliance** = physical device for petabyte-scale offline transfers when network bandwidth is insufficient.
 
-**Docs:** [Database Migration Service](https://cloud.google.com/database-migration/docs) | [Migrate to Containers](https://cloud.google.com/migrate/containers/docs) | [Migrate to VMs](https://cloud.google.com/migrate/compute-engine/docs) | [Migration Center](https://cloud.google.com/migration-center/docs) | [Storage Transfer Service](https://cloud.google.com/storage-transfer-service/docs) | [BigQuery Data Transfer Service](https://cloud.google.com/bigquery/docs/transfer-service-overview) | [Datastream](https://cloud.google.com/datastream/docs)
+**Docs:** [Database Migration Service](https://cloud.google.com/database-migration/docs) | [Migrate to Containers](https://cloud.google.com/migrate/containers/docs) | [Migrate to Containers CLI reference](https://cloud.google.com/migrate/containers/docs/m2c-cli-reference-linux) | [Migrate to VMs](https://cloud.google.com/migrate/virtual-machines/docs) | [Migration Center](https://cloud.google.com/migration-center/docs) | [Storage Transfer Service](https://cloud.google.com/storage-transfer/docs/overview) | [BigQuery Data Transfer Service](https://cloud.google.com/bigquery/docs/transfer-service-overview) | [Datastream](https://cloud.google.com/datastream/docs)
 
 ---
 
@@ -618,8 +626,8 @@ Cloud Shell is a free, browser-based terminal with a persistent 5 GB home direct
 
 - `gcloud`, `gsutil`, `bq`, `kubectl`, `terraform`, `docker`, `git`, `python`, `java`, `go`, `node`
 - Authenticated automatically with your logged-in account
-- Ephemeral VM (Debian-based, `e2-small`), resets after 120 minutes of inactivity
-- Home directory persists across sessions (5 GB limit)
+- Ephemeral Debian-based VM; the session ends after **40 minutes** of inactivity
+- Home directory persists across sessions (5 GB limit), but is **deleted after 120 days** without accessing Cloud Shell
 
 ```bash
 # Cloud Shell is accessed via the console (top-right terminal icon)
@@ -642,9 +650,11 @@ cloudshell edit ~/my-file.py
 
 **Cloud Shell limitations:**
 
-- 50 hours/week usage limit
+- 50 hours/week usage quota
 - No GPU, limited CPU/RAM
-- Sessions timeout after 20 minutes of idle (terminal) or 120 minutes (VM)
+- Session ends after **40 minutes** of inactivity
+- **12-hour** maximum session length, then the session terminates regardless of activity
+- `$HOME` is **deleted after 120 days** of not using Cloud Shell
 - Not for production workloads -- development and admin tasks only
 - 5 GB home directory limit
 
@@ -723,8 +733,8 @@ gcloud workstations ssh my-workstation \
 |---------|------------|-------------------|
 | **Cost** | Free | Paid (Compute Engine pricing) |
 | **Persistence** | 5 GB home dir only | Full VM disk persists |
-| **Machine type** | Fixed (e2-small) | Configurable (any machine type) |
-| **Idle timeout** | 20 min (terminal), 120 min (VM) | Configurable |
+| **Machine type** | Fixed, not configurable | Configurable (any machine type) |
+| **Idle timeout** | 40 min inactivity, 12 h session cap | Configurable |
 | **Custom images** | No | Yes (bring your own container image) |
 | **GPU** | No | Yes |
 | **Use case** | Quick admin tasks, tutorials | Full development environment, teams |
@@ -733,11 +743,12 @@ gcloud workstations ssh my-workstation \
 > **Exam tips:**
 > - Cloud Shell = free, quick, ephemeral. Cloud Workstations = paid, persistent, customizable.
 > - Cloud Shell's 5 GB home directory persists, but the VM environment resets. Anything installed outside `$HOME` is lost.
+> - Cloud Shell numbers worth memorising: 40 min inactivity timeout, 12 h session cap, 50 h/week quota, 5 GB `$HOME`, `$HOME` deleted after 120 days unused.
 > - Cloud Code is the IDE plugin (VS Code/IntelliJ). Cloud Shell Editor is the browser-based IDE.
 > - Cloud Workstations can connect to private VPC networks -- Cloud Shell cannot.
 > - If the question mentions "team development environment" or "custom IDE configuration," the answer is Cloud Workstations.
 
-**Docs:** [Cloud Shell](https://cloud.google.com/shell/docs) | [Cloud Code](https://cloud.google.com/code/docs) | [Cloud Workstations](https://cloud.google.com/workstations/docs)
+**Docs:** [Cloud Shell](https://cloud.google.com/shell/docs) | [Cloud Shell limitations](https://cloud.google.com/shell/docs/limitations) | [Cloud Code](https://cloud.google.com/code/docs) | [Cloud Workstations](https://cloud.google.com/workstations/docs)
 
 ---
 
@@ -789,128 +800,29 @@ gcloud ... --verbosity=debug  # Debug output
 gcloud ... --impersonate-service-account=SA@PROJECT.iam.gserviceaccount.com
 ```
 
-#### gsutil (Cloud Storage)
+#### Service-Specific CLIs
+
+The exam does not test flag recall for these. It tests which tool owns which surface, and which tool a script or runbook should standardise on.
+
+| CLI | Surface | Architect-Level Point |
+|-----|---------|-----------------------|
+| `gcloud storage` | Cloud Storage | The current tool. Faster than `gsutil` on large transfers because it parallelises by default |
+| `gsutil` | Cloud Storage | Legacy. Leaves the CLI bundle in March 2027, so new automation should target `gcloud storage` |
+| `bq` | BigQuery | Datasets, tables, loads, extracts, and `--transfer_config` for BigQuery Data Transfer Service |
+| `cbt` | Bigtable | Separate component (`gcloud components install cbt`), schema and row-level operations only |
+| `kubectl` | GKE workloads | Credentials come from `gcloud container clusters get-credentials`, which writes the kubeconfig entry |
 
 ```bash
-# Copy files
-gsutil cp local-file.txt gs://my-bucket/
-gsutil cp gs://my-bucket/file.txt .
-gsutil cp -r local-dir/ gs://my-bucket/dir/  # Recursive
+# gcloud storage covers the common data-movement cases
+gcloud storage cp -r local-dir/ gs://my-bucket/dir/
+gcloud storage rsync -r local-dir/ gs://my-bucket/dir/
+gcloud storage buckets update gs://my-bucket --versioning
 
-# Parallel composite upload (large files)
-gsutil -o GSUtil:parallel_composite_upload_threshold=150M cp large-file.tar.gz gs://my-bucket/
-
-# Sync directories
-gsutil rsync -r local-dir/ gs://my-bucket/dir/
-gsutil rsync -d -r gs://source-bucket/ gs://dest-bucket/  # -d deletes extra files in dest
-
-# List and manage
-gsutil ls gs://my-bucket/
-gsutil ls -l gs://my-bucket/  # Long listing with sizes
-gsutil du -s gs://my-bucket/  # Total bucket size
-
-# ACLs and IAM
-gsutil iam get gs://my-bucket/
-gsutil iam ch user:dev@example.com:objectViewer gs://my-bucket/
-
-# Lifecycle and versioning
-gsutil versioning set on gs://my-bucket/
-gsutil lifecycle set lifecycle.json gs://my-bucket/
-
-# Multi-threaded operations
-gsutil -m cp -r large-dir/ gs://my-bucket/  # -m enables multi-threading
-gsutil -m rsync -r source/ gs://my-bucket/dest/
+# Get GKE credentials, then kubectl works against the cluster
+gcloud container clusters get-credentials my-cluster --region=us-central1
 ```
 
-> **Note:** `gsutil` is gradually being replaced by `gcloud storage` commands, but `gsutil` is still widely used and exam-relevant.
-
-```bash
-# gcloud storage equivalents (newer, faster)
-gcloud storage cp local-file.txt gs://my-bucket/
-gcloud storage ls gs://my-bucket/
-gcloud storage rsync local-dir/ gs://my-bucket/dir/
-```
-
-#### bq CLI (BigQuery)
-
-```bash
-# Run a query
-bq query --use_legacy_sql=false 'SELECT * FROM `my-project.my_dataset.my_table` LIMIT 10'
-
-# Create a dataset
-bq mk --dataset my-project:my_dataset
-
-# Create a table
-bq mk --table my-project:my_dataset.my_table schema.json
-
-# Load data
-bq load --source_format=CSV my_dataset.my_table gs://my-bucket/data.csv schema.json
-bq load --autodetect --source_format=NEWLINE_DELIMITED_JSON my_dataset.my_table gs://my-bucket/data.jsonl
-
-# Export data
-bq extract my_dataset.my_table gs://my-bucket/export/data-*.csv
-
-# List datasets, tables, jobs
-bq ls
-bq ls my_dataset
-bq ls --jobs --all
-
-# Show table details
-bq show my_dataset.my_table
-bq show --schema my_dataset.my_table
-```
-
-#### cbt CLI (Bigtable)
-
-```bash
-# Install cbt
-gcloud components install cbt
-
-# Configure cbt
-echo project=my-project > ~/.cbtrc
-echo instance=my-bigtable-instance >> ~/.cbtrc
-
-# List tables
-cbt ls
-
-# Create a table and column family
-cbt createtable my-table
-cbt createfamily my-table cf1
-
-# Read/write data
-cbt set my-table row1 cf1:col1=value1
-cbt read my-table
-
-# Count rows
-cbt count my-table
-
-# Delete
-cbt deleterow my-table row1
-cbt deletetable my-table
-```
-
-#### kubectl (GKE)
-
-```bash
-# Get credentials for a GKE cluster
-gcloud container clusters get-credentials my-cluster --zone=us-central1-a
-
-# Common kubectl commands
-kubectl get pods
-kubectl get services
-kubectl get deployments
-kubectl get nodes
-kubectl describe pod POD_NAME
-kubectl logs POD_NAME
-kubectl exec -it POD_NAME -- /bin/bash
-kubectl apply -f manifest.yaml
-kubectl delete -f manifest.yaml
-kubectl scale deployment my-app --replicas=5
-kubectl rollout status deployment/my-app
-kubectl rollout undo deployment/my-app
-kubectl top pods  # Resource usage (requires metrics-server)
-kubectl top nodes
-```
+> **Exam tip:** a question that contrasts `gsutil` with `gcloud storage` is asking which one to build new automation on. That is `gcloud storage`. A question that names `gsutil signurl` is testing something else: signing a URL that way needs a downloaded service account key, so the correct answer is `gcloud storage sign-url --impersonate-service-account`.
 
 #### SDK Client Libraries
 
@@ -1121,11 +1033,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.0"
+      version = "~> 7.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.0"
+      version = "~> 7.0"
     }
   }
 }
@@ -1259,7 +1171,7 @@ resource "google_compute_instance" "my_vm" {
 }
 ```
 
-**Terraform Cloud / Terraform Enterprise:**
+**HCP Terraform / Terraform Enterprise** (HCP Terraform is the current name for what was Terraform Cloud):
 
 - Remote execution (runs Terraform in the cloud, not locally)
 - State management with built-in locking and versioning
@@ -1668,7 +1580,7 @@ resource "google_cloud_run_v2_service" "default" {
 
   template {
     containers {
-      image = "gcr.io/${var.project_id}/my-app:latest"
+      image = "us-central1-docker.pkg.dev/${var.project_id}/my-repo/my-app:latest"
 
       ports {
         container_port = 8080
@@ -1723,7 +1635,7 @@ resource "google_cloud_run_v2_service_iam_member" "public" {
 
 #### Policy Validation
 
-**Sentinel (Terraform Cloud/Enterprise):**
+**Sentinel (HCP Terraform / Terraform Enterprise):**
 
 ```python
 # Sentinel policy: Ensure all GCE instances use approved machine types
@@ -1806,39 +1718,51 @@ kubectl apply -f storage-bucket.yaml
 kubectl describe storagebucket my-bucket
 ```
 
-**Deployment Manager (legacy, avoid for new projects):**
+**Infrastructure Manager (Google's managed Terraform):**
 
-Deployment Manager is Google's native IaC tool using YAML/Jinja2/Python templates. It is legacy and not recommended for new projects. Use Terraform instead.
+Infrastructure Manager (Infra Manager) runs *your* Terraform configuration as a managed Google Cloud service. You do not run `terraform apply` yourself and you do not own a state bucket: Infra Manager creates a Cloud Build run that performs `init`, `validate`, `plan` and `apply`, and stores the resulting Terraform state and logs in a Cloud Storage bucket it manages. It is the named successor to Deployment Manager.
 
-```yaml
-# deployment.yaml (Deployment Manager)
-resources:
-  - name: my-vm
-    type: compute.v1.instance
-    properties:
-      zone: us-central1-a
-      machineType: zones/us-central1-a/machineTypes/e2-medium
-      disks:
-        - deviceName: boot
-          type: PERSISTENT
-          boot: true
-          autoDelete: true
-          initializeParams:
-            sourceImage: projects/debian-cloud/global/images/family/debian-12
-      networkInterfaces:
-        - network: global/networks/default
-```
+The config source can be a Cloud Storage object, a public Git repository, or your local machine. Infra Manager executes it under a **service account you nominate**, which is what makes it the answer when a question asks for Terraform runs with no long-lived developer credentials and a per-deployment audit trail.
+
+| Concept | What It Is |
+|---------|-----------|
+| **Deployment** | The unit of managed infrastructure, holding the current state |
+| **Revision** | One apply of a deployment. Each revision keeps its own config, resource list, logs and state file |
+| **Preview** | A plan-only run showing the effect of a change before it is applied |
+| **Resource drift** | Detected difference between the live resources and the last applied revision |
 
 ```bash
-# Deploy with Deployment Manager
-gcloud deployment-manager deployments create my-deployment --config=deployment.yaml
+# Apply a deployment from a Cloud Storage source
+gcloud infra-manager deployments apply projects/PROJECT/locations/us-central1/deployments/my-deployment \
+  --service-account=projects/PROJECT/serviceAccounts/infra-manager-sa@PROJECT.iam.gserviceaccount.com \
+  --gcs-source=gs://my-config-bucket/terraform/ \
+  --input-values=project_id=PROJECT,region=us-central1
 
-# Update
-gcloud deployment-manager deployments update my-deployment --config=deployment-v2.yaml
+# Apply from a public Git repository
+gcloud infra-manager deployments apply projects/PROJECT/locations/us-central1/deployments/my-deployment \
+  --service-account=projects/PROJECT/serviceAccounts/infra-manager-sa@PROJECT.iam.gserviceaccount.com \
+  --git-source-repo=https://github.com/example/infra \
+  --git-source-directory=envs/prod \
+  --git-source-ref=main
 
-# Delete
-gcloud deployment-manager deployments delete my-deployment
+# Preview a change before applying it
+gcloud infra-manager previews create projects/PROJECT/locations/us-central1/previews/my-preview \
+  --deployment=projects/PROJECT/locations/us-central1/deployments/my-deployment \
+  --service-account=projects/PROJECT/serviceAccounts/infra-manager-sa@PROJECT.iam.gserviceaccount.com
+
+# Inspect history, and the drift a preview detected
+gcloud infra-manager revisions list --deployment=my-deployment --location=us-central1
+gcloud infra-manager resource-drifts list --preview=my-preview --location=us-central1
+
+# Tear down the managed resources
+gcloud infra-manager deployments delete projects/PROJECT/locations/us-central1/deployments/my-deployment
 ```
+
+Constraints worth knowing: the configuration must not declare its own `backend` block (Infra Manager owns the state), Terraform `provisioners` are not supported, and the Terraform version comes from the set Infra Manager supports (`gcloud infra-manager terraform-versions list`) rather than being pinned freely.
+
+**Deployment Manager (end of support, do not use):**
+
+Deployment Manager is Google's original native IaC service, using YAML with Jinja2 or Python templates. It reached end of support on 2026-03-31 and new users are blocked from 2026-06-30. Google's stated migration path is Infrastructure Manager or Terraform. Treat it as a distractor on the exam: the only correct answer involving it is "migrate off it".
 
 **Pulumi (third-party, multi-cloud):**
 
@@ -1846,16 +1770,16 @@ Pulumi uses general-purpose programming languages (Python, Go, TypeScript, Java)
 
 #### IaC Comparison Table
 
-| Feature | Terraform | Deployment Manager | Config Connector | Pulumi |
-|---------|-----------|-------------------|-----------------|--------|
-| **Language** | HCL | YAML/Jinja2/Python | YAML (K8s CRDs) | Python, Go, TS, Java |
-| **State** | Managed (local/remote) | GCP-managed | Kubernetes etcd | Managed (Pulumi Cloud) |
-| **Multi-cloud** | Yes | No (GCP only) | No (GCP only) | Yes |
-| **Status** | Recommended | Legacy | Active (K8s teams) | Active |
-| **Community** | Largest | Small | Growing | Growing |
-| **GCP support** | Comprehensive | Full | Comprehensive | Comprehensive |
-| **GitOps** | Via CI/CD | No | Native (K8s) | Via CI/CD |
-| **Best for** | Most teams | (don't use) | K8s-native teams | Dev teams who prefer code |
+| Feature | Terraform (self-run) | Infrastructure Manager | Config Connector | Pulumi | Deployment Manager |
+|---------|----------------------|------------------------|------------------|--------|--------------------|
+| **Language** | HCL | HCL (your Terraform config) | YAML (K8s CRDs) | Python, Go, TS, Java | YAML/Jinja2/Python |
+| **Who runs it** | You (laptop or CI) | Google, via Cloud Build | Config Connector in GKE | You or Pulumi Cloud | Google |
+| **State** | You own it (GCS backend) | Google-managed bucket, per revision | Kubernetes etcd | Managed (Pulumi Cloud) | Google-managed |
+| **Identity used** | Whatever the runner has | A service account you nominate | Workload Identity in the cluster | Whatever the runner has | Caller's credentials |
+| **Multi-cloud** | Yes | No (Google Cloud only) | No (Google Cloud only) | Yes | No |
+| **Status** | Recommended | Recommended, Google-managed | Active (K8s teams) | Active | End of support 2026-03-31 |
+| **GitOps** | Via CI/CD | Native Git source, or via CI/CD | Native (K8s) | Via CI/CD | No |
+| **Best for** | Teams with existing CI/CD | Teams who want Terraform without owning runners or state | K8s-native teams | Dev teams who prefer code | Nothing new |
 
 > **Exam tips:**
 > - **Terraform is the default answer** for IaC on the PCA exam. If the question doesn't mention Kubernetes-native, pick Terraform.
@@ -1865,13 +1789,14 @@ Pulumi uses general-purpose programming languages (Python, Go, TypeScript, Java)
 > - **`terraform state rm`** removes a resource from state WITHOUT deleting the actual resource. Use when you want to stop managing a resource.
 > - **CFT modules** are the Google-recommended Terraform modules. If the question says "Google best practices" or "opinionated modules," pick CFT.
 > - **Config Connector** = Kubernetes-native IaC. If the question says "manage GCP resources with kubectl" or "Kubernetes-style declarative management," pick Config Connector.
-> - **Deployment Manager** is legacy. The exam may include it as a distractor. If the question asks for the "recommended" approach, pick Terraform.
+> - **Infrastructure Manager** is the answer when the requirement is Terraform *without* the team owning runners, state buckets or long-lived credentials: it runs the config under a nominated service account and keeps state and logs per revision. Also the answer to "what replaces Deployment Manager".
+> - **Deployment Manager** hit end of support on 2026-03-31 and is closed to new users. It is only ever a distractor, or the thing being migrated away from.
 > - **Workspaces vs directories:** Workspaces are simpler but less visible. Separate directories per environment are recommended for production setups.
-> - **Sentinel** = policy as code for Terraform Cloud/Enterprise. **OPA/Gatekeeper** = open-source alternative.
+> - **Sentinel** = policy as code for HCP Terraform / Terraform Enterprise. **OPA/Gatekeeper** = open-source alternative.
 > - `terraform plan -out=plan.tfplan` then `terraform apply plan.tfplan` is the safest workflow (ensures you apply exactly what you reviewed).
 > - Always enable **versioning on the state bucket** so you can recover from state corruption.
 
-**Docs:** [Terraform Google Provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs) | [Cloud Foundation Toolkit](https://cloud.google.com/docs/terraform/blueprints/terraform-blueprints) | [Config Connector](https://cloud.google.com/config-connector/docs/overview) | [Deployment Manager](https://cloud.google.com/deployment-manager/docs) | [Terraform best practices on GCP](https://cloud.google.com/docs/terraform/best-practices-for-terraform)
+**Docs:** [Terraform Google Provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs) | [Infrastructure Manager](https://cloud.google.com/infrastructure-manager/docs/overview) | [`gcloud infra-manager`](https://cloud.google.com/sdk/gcloud/reference/infra-manager) | [Cloud Foundation Toolkit](https://cloud.google.com/docs/terraform/blueprints/terraform-blueprints) | [Config Connector](https://cloud.google.com/config-connector/docs/overview) | [Deployment Manager deprecation](https://cloud.google.com/deployment-manager/docs/deprecations) | [Terraform best practices on GCP](https://cloud.google.com/docs/terraform/best-practices-for-terraform)
 
 ---
 
@@ -1921,7 +1846,7 @@ curl "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest"
 # ADC resolution order:
 # 1. GOOGLE_APPLICATION_CREDENTIALS environment variable (path to service account key JSON)
 # 2. gcloud auth application-default credentials (~/.config/gcloud/application_default_credentials.json)
-# 3. Attached service account (on GCE, GKE, Cloud Run, Cloud Functions)
+# 3. Attached service account (on GCE, GKE, Cloud Run, Cloud Run functions)
 # 4. Compute Engine default service account
 
 # Set ADC for local development
@@ -1961,72 +1886,28 @@ client = storage.Client(credentials=credentials)
 
 #### Rate Limiting and Error Handling
 
-```python
-# Python: Exponential backoff with google-cloud libraries
-# Most client libraries handle retries automatically
+Cloud Client Libraries already implement the correct behaviour, so the architect-level decision is whether to use them rather than how to hand-roll the loop.
 
-# Manual retry with exponential backoff
-import time
-import random
+| Failure | Correct Response | Who Implements It |
+|---------|------------------|-------------------|
+| `429 RESOURCE_EXHAUSTED` (rate quota) | Exponential backoff with jitter, then retry | Cloud Client Library, via `google.api_core.retry` |
+| `503 UNAVAILABLE` | Same, retry is safe for idempotent calls | Cloud Client Library |
+| `403` allocation quota exceeded | Do not retry, request a quota increase | You |
+| Long result sets | Follow `nextPageToken` until absent | Cloud Client Library iterators |
+
+```python
+# The retry policy is configuration, not code you write
 from google.api_core import exceptions, retry
 
-# Using the built-in retry decorator
-@retry.Retry(
-    initial=1.0,        # Initial delay in seconds
-    maximum=60.0,       # Maximum delay
-    multiplier=2.0,     # Delay multiplier
-    deadline=300.0,     # Total timeout
+retry_policy = retry.Retry(
+    initial=1.0, maximum=60.0, multiplier=2.0, deadline=300.0,
     predicate=retry.if_exception_type(
-        exceptions.ServiceUnavailable,
-        exceptions.TooManyRequests,
+        exceptions.ServiceUnavailable, exceptions.TooManyRequests
     ),
 )
-def make_api_call():
-    # Your API call here
-    pass
-
-# Manual exponential backoff pattern
-def call_with_backoff(func, max_retries=5):
-    for attempt in range(max_retries):
-        try:
-            return func()
-        except exceptions.TooManyRequests:
-            if attempt == max_retries - 1:
-                raise
-            delay = (2 ** attempt) + random.uniform(0, 1)
-            time.sleep(delay)
 ```
 
-**Pagination:**
-
-```python
-# Most list operations return paginated results
-from google.cloud import storage
-
-client = storage.Client()
-
-# Client libraries handle pagination automatically with iterators
-blobs = client.list_blobs('my-bucket', prefix='data/')
-for blob in blobs:  # Automatically paginates
-    print(blob.name)
-
-# Manual pagination with page tokens (REST API)
-import requests
-
-url = "https://storage.googleapis.com/storage/v1/b/my-bucket/o"
-params = {"maxResults": 100}
-headers = {"Authorization": f"Bearer {access_token}"}
-
-while True:
-    response = requests.get(url, params=params, headers=headers)
-    data = response.json()
-    for item in data.get("items", []):
-        print(item["name"])
-    page_token = data.get("nextPageToken")
-    if not page_token:
-        break
-    params["pageToken"] = page_token
-```
+> **Exam tip:** an option describing a hand-written retry or page-token loop is usually the wrong answer. The right one is "use the Cloud Client Library", which does both. Retrying a **403 allocation quota** error is always wrong: allocation quotas are hard limits, only rate quotas refill.
 
 #### API Quotas and Limits
 
@@ -2035,9 +1916,9 @@ while True:
 gcloud compute project-info describe --project=my-project --format="table(quotas.metric,quotas.usage,quotas.limit)"
 
 # Request a quota increase
-# Console: IAM & Admin > Quotas > Select quota > Edit Quotas
-# Or via gcloud:
-gcloud services quota update \
+# Console: IAM & Admin > Quotas & System Limits > select quota > Edit
+# The gcloud path is alpha only, so do not expect it as a correct exam answer:
+gcloud alpha services quota update \
   --service=compute.googleapis.com \
   --consumer=projects/my-project \
   --metric=compute.googleapis.com/cpus \
@@ -2085,77 +1966,18 @@ pip install google-cloud-monitoring     # Cloud Monitoring
 pip install google-cloud-secret-manager # Secret Manager
 ```
 
-```python
-# Pub/Sub: Publish and subscribe
-from google.cloud import pubsub_v1
-from concurrent.futures import TimeoutError
-
-# Publisher
-publisher = pubsub_v1.PublisherClient()
-topic_path = publisher.topic_path("my-project", "my-topic")
-
-future = publisher.publish(topic_path, b"My message", attribute1="value1")
-print(f"Published: {future.result()}")
-
-# Subscriber
-subscriber = pubsub_v1.SubscriberClient()
-subscription_path = subscriber.subscription_path("my-project", "my-sub")
-
-def callback(message):
-    print(f"Received: {message.data}")
-    message.ack()
-
-streaming_pull_future = subscriber.subscribe(subscription_path, callback=callback)
-try:
-    streaming_pull_future.result(timeout=60)
-except TimeoutError:
-    streaming_pull_future.cancel()
-    streaming_pull_future.result()
-```
+The shape is the same in every language and every service: construct a client with no explicit credentials so it picks up ADC, then call the resource method.
 
 ```python
-# Secret Manager: Access secrets
-from google.cloud import secretmanager
+# One pattern, three services
+from google.cloud import storage, pubsub_v1, secretmanager
 
-client = secretmanager.SecretManagerServiceClient()
-name = f"projects/my-project/secrets/my-secret/versions/latest"
-response = client.access_secret_version(request={"name": name})
-secret_value = response.payload.data.decode("UTF-8")
+storage.Client()                                  # ADC
+pubsub_v1.PublisherClient()                       # ADC
+secretmanager.SecretManagerServiceClient()        # ADC
 ```
 
-```go
-// Go: Cloud Storage example
-package main
-
-import (
-    "context"
-    "fmt"
-    "io"
-
-    "cloud.google.com/go/storage"
-)
-
-func readObject(bucket, object string) ([]byte, error) {
-    ctx := context.Background()
-    client, err := storage.NewClient(ctx)  // Uses ADC
-    if err != nil {
-        return nil, fmt.Errorf("storage.NewClient: %w", err)
-    }
-    defer client.Close()
-
-    rc, err := client.Bucket(bucket).Object(object).NewReader(ctx)
-    if err != nil {
-        return nil, fmt.Errorf("Object.NewReader: %w", err)
-    }
-    defer rc.Close()
-
-    data, err := io.ReadAll(rc)
-    if err != nil {
-        return nil, fmt.Errorf("io.ReadAll: %w", err)
-    }
-    return data, nil
-}
-```
+The architect-level point is what the client picks up *from the environment*: on Compute Engine, GKE, Cloud Run and Cloud Run functions the attached service account is used with no configuration, which is why an attached service account beats any credential the code carries.
 
 #### Google API Client Libraries (Lower-Level)
 
@@ -2253,9 +2075,10 @@ Need to migrate data?
 └── Need assessment first → Migration Center
 
 Need Infrastructure as Code?
-├── General purpose (recommended) → Terraform
+├── General purpose, team already has CI/CD → Terraform
+├── Want Terraform but not the runners or state → Infrastructure Manager
 ├── Kubernetes-native team → Config Connector
-├── Existing Deployment Manager → Migrate to Terraform
+├── Existing Deployment Manager → Migrate to Infrastructure Manager or Terraform
 └── Prefer real programming languages → Pulumi
 
 Need local development/testing?
@@ -2268,7 +2091,8 @@ Need to authenticate?
 ├── GCP workload → Attached service account (ADC)
 ├── Local development → gcloud auth application-default login
 ├── External workload (AWS/Azure/GitHub) → Workload Identity Federation
-└── CI/CD pipeline → Service account with key (or WIF)
+├── CI/CD outside Google Cloud → Workload Identity Federation, repository-scoped attribute condition
+└── Human needs a service account's access → Impersonation, never a downloaded key
 ```
 
 ---
@@ -2282,6 +2106,7 @@ Need to authenticate?
 - [ ] Can you explain ADC resolution order?
 - [ ] Do you know which services have emulators and how to start them?
 - [ ] Can you distinguish Cloud Shell vs Cloud Workstations?
-- [ ] Do you know when to use Config Connector vs Terraform?
+- [ ] Do you know when to use Config Connector vs Terraform vs Infrastructure Manager?
+- [ ] Can you say what replaced Deployment Manager, and what replaced `migctl`?
 - [ ] Can you explain Workload Identity Federation vs service account keys?
 - [ ] Do you know the difference between Cloud Client Libraries and Google API Client Libraries?

--- a/gcp/pca/docs/06-solution-operations-excellence.md
+++ b/gcp/pca/docs/06-solution-operations-excellence.md
@@ -10,16 +10,29 @@
 
 The **Operational Excellence** pillar is one of six pillars in the Google Cloud Well-Architected Framework (along with Reliability, Security, Performance Optimization, Cost Optimization, and Sustainability). It focuses on running workloads effectively, monitoring them proactively, and continuously improving processes.
 
-### Key Principles
+### The Published Principles
 
-| Principle | What It Means | Exam Relevance |
-|-----------|---------------|----------------|
-| **Automate everything** | Eliminate manual, repetitive tasks (toil) through IaC, CI/CD, auto-remediation | Questions about reducing operational burden |
-| **Monitor before you act** | Observability must be in place before making changes; data-driven decisions | Questions about what to set up first |
-| **Reduce toil** | Toil = manual, repetitive, automatable, tactical, devoid of long-term value | Questions referencing SRE toil concepts |
-| **Learn from failure** | Blameless post-mortems, incident reviews, chaos engineering | Questions about incident response |
-| **Design for operability** | Systems should be easy to deploy, update, and debug | Questions about choosing architectures |
-| **Gradual rollouts** | Progressive delivery reduces blast radius | Questions about deployment strategies |
+Objective 6.1 reads "the principles and recommendations of the operational excellence pillar", so learn Google's five published principles as written. A question may quote one of these headings almost verbatim.
+
+| Principle (as published) | What It Covers |
+|--------------------------|----------------|
+| **Ensure operational readiness and performance using CloudOps** | Define SLOs, instrument for observability, test before launch, plan capacity |
+| **Manage incidents and problems** | Detect, respond, mitigate, then run retrospectives and close the preventive actions |
+| **Manage and optimize cloud resources** | Right-size, autoscale, and monitor cost as an operational signal, not a finance-only one |
+| **Automate and manage change** | IaC, CI/CD, progressive rollouts, and a change process that makes rollback cheap |
+| **Continuously improve and innovate** | Feed what operations learns back into design; adopt new capability deliberately |
+
+### SRE as the Supporting Model
+
+Google's operational excellence guidance is built on Site Reliability Engineering, so the SRE vocabulary is what the exam's distractors are drawn from. These are supporting concepts, not the pillar principles themselves:
+
+| Concept | Definition | Where It Shows Up |
+|---------|-----------|-------------------|
+| **Toil** | Manual, repetitive, automatable, tactical work with no enduring value, scaling linearly with the service | "Team spends 60% of time on deployments" |
+| **Error budget** | 1 minus the SLO. Spending it is allowed; exhausting it freezes feature work | "What do we do when we miss the SLO?" |
+| **Blameless post-mortem** | Incident review focused on systemic cause, not individual fault | "The team blamed one engineer" |
+| **Progressive delivery** | Canary or blue/green rollout that bounds the blast radius | "How do we deploy this safely?" |
+| **Golden signals** | Latency, traffic, errors, saturation | "What should we alert on?" |
 
 ### How Operational Excellence Appears in Exam Questions
 
@@ -41,13 +54,38 @@ Level 3: Predictive   --> ML-based anomaly detection, chaos engineering, self-he
 
 The exam expects Level 2-3 thinking. If a question describes manual or ad-hoc operations, the answer almost always involves automation and monitoring.
 
+### DORA Metrics
+
+DORA is Google's own software delivery research programme, and its metrics are the standard answer to "how do we measure whether our delivery process is improving?" They measure the **delivery pipeline**, not the running service, which is what separates them from SLOs.
+
+| Metric | What It Measures | Axis |
+|--------|------------------|------|
+| **Deployment frequency** | How often deployments reach production | Throughput |
+| **Change lead time** | Commit to running in production | Throughput |
+| **Change fail rate** | Share of deployments needing immediate intervention | Stability |
+| **Deployment rework rate** | Share of deployments that are unplanned, caused by a production incident | Stability |
+| **Failed deployment recovery time** | Time to recover from a deployment that failed | Stability |
+
+The throughput/stability split is the exam-relevant part: the research finding is that these move **together**, not against each other. An option that frames the choice as "ship faster or be more stable" is the wrong answer. Practices that improve both are the same ones the operational excellence pillar recommends: trunk-based development, small batches, automated testing, and progressive delivery.
+
+| Signal in a Question | Metric It Points To | Typical GCP Answer |
+|----------------------|---------------------|--------------------|
+| "We deploy once a quarter" | Deployment frequency | Cloud Build + Cloud Deploy pipeline |
+| "Two weeks from merge to production" | Change lead time | Automated promotion with approval gates |
+| "One in four releases breaks something" | Change fail rate | Canary with automated rollback |
+| "It takes hours to get back to a good version" | Failed deployment recovery time | Cloud Deploy rollback, or blue/green traffic switch |
+
 **Exam tips:**
+- DORA metrics measure the **pipeline**; SLOs measure the **service**. A question about customer-visible reliability wants an SLO, not deployment frequency.
 - If a question mentions "toil" or "manual repetitive tasks," the answer is automation (Cloud Build, Cloud Deploy, Terraform, etc.).
 - Operational excellence questions often have a "cultural" best-answer (blameless post-mortems) over a purely technical one.
 - "Monitor first, then act" is a recurring theme -- you cannot optimize what you cannot measure.
 
 **Docs:**
 - [Well-Architected Framework: Operational Excellence](https://cloud.google.com/architecture/framework/operational-excellence)
+- [Operational excellence principles](https://cloud.google.com/architecture/framework/operational-excellence/principles)
+- [DORA research and metrics](https://dora.dev/)
+- [Four Keys on Google Cloud](https://cloud.google.com/blog/products/devops-sre/using-the-four-keys-to-measure-your-devops-performance)
 - [SRE Book: Eliminating Toil](https://sre.google/sre-book/eliminating-toil/)
 - [Google Cloud Architecture Framework](https://cloud.google.com/architecture/framework)
 
@@ -65,11 +103,14 @@ Cloud Monitoring is the central metrics, dashboards, and alerting platform in Go
 
 | Metric Type | Source | Example | Retention |
 |-------------|--------|---------|-----------|
-| **Built-in (system)** | Auto-collected from GCP services | `compute.googleapis.com/instance/cpu/utilization` | 5 years (6 weeks full-res, then downsampled) |
-| **Custom metrics** | Written via API or client libraries | `custom.googleapis.com/orders/per_minute` | 24 months |
-| **Prometheus metrics** | Scraped by GMP (Managed Service for Prometheus) | `http_requests_total` | 24 months in Monarch |
-| **External metrics** | From AWS, on-prem via agent | `external.googleapis.com/...` | 24 months |
-| **Log-based metrics** | Derived from Cloud Logging | Counter or distribution from log entries | 24 months |
+| **Built-in (major services)** | Compute Engine, GKE, Cloud Storage, BigQuery, Cloud SQL, load balancers | `compute.googleapis.com/instance/cpu/utilization` | 24 months (6 weeks at native resolution, then 10-minute samples) |
+| **Custom metrics** | Written via API or client libraries | `custom.googleapis.com/orders/per_minute` | 24 months (same 6-week then 10-minute schedule) |
+| **Prometheus and OTLP metrics** | Scraped by GMP (Managed Service for Prometheus) | `http_requests_total` | 24 months (1 week native, then 1-minute for 5 weeks, then 10-minute) |
+| **External, workload and agent metrics** | On-prem or third-party, via agent | `external.googleapis.com/...` | 24 months |
+| **All other Google Cloud metrics, plus Istio** | Services outside the list above | varies | 6 weeks |
+| **Log-based metrics** | Derived from Cloud Logging | Counter or distribution from log entries | **6 weeks** |
+
+**Exam trap:** metric retention tops out at **24 months**, never years beyond that, and **log-based metrics only keep 6 weeks**. If a requirement is "retain this signal for a year or more", the answer is to route the underlying logs to a **log bucket with a longer retention** or to BigQuery, not to rely on the metric.
 
 ```bash
 # There is no `gcloud monitoring metrics-descriptors` group. The GA groups under
@@ -203,7 +244,7 @@ gcloud monitoring uptime delete my-service-check
 Types of uptime checks:
 - **HTTP/HTTPS**: Check URL availability and response codes
 - **TCP**: Check port connectivity
-- **Custom**: Use Cloud Functions for complex health checks
+- **Custom**: Use Cloud Run functions for complex health checks
 
 Configuration options:
 - Check frequency: 1, 5, 10, or 15 minutes
@@ -283,7 +324,37 @@ Resource groups let you organize monitored resources for collective dashboards a
 # Groups are dynamic -- resources matching the filter are auto-included
 ```
 
+#### Metrics Scopes (Multi-Project Observability)
+
+A **metrics scope** defines which projects' time-series data a given project can chart, alert on and dashboard. This is the architect-level Cloud Monitoring topic: in a project-per-environment or project-per-team layout, every project starts isolated, and the metrics scope is the mechanism that produces a single pane of glass.
+
+| Term | Meaning |
+|------|---------|
+| **Metrics scope** | The set of resource containers whose metrics a project can read |
+| **Scoping project** | The project that hosts the metrics scope. It stores the dashboards, alerting policies, uptime checks and synthetic monitors |
+| **Monitored project** | A project whose metrics have been added to another project's scope |
+
+Key behaviours:
+
+- Every project is its own scoping project by default, with a metrics scope containing only itself.
+- A monitored project can belong to more than one metrics scope.
+- Time series carry a project identifying label, so you can filter and group by project inside the scoping project.
+- Adding a project to a scope grants **read** access to its metrics. It does not move or copy data, and it does not change where the metrics are billed.
+- Supported limit is **375 monitored projects** per metrics scope for performant queries. Up to 3,500 can be added, with degraded query performance, and the quota is increasable.
+
+The canonical pattern: create a dedicated observability project, add every environment project to its metrics scope, and build the cross-environment dashboards and alerts there.
+
+```bash
+# Metrics scope membership is managed in the console under Monitoring > Settings,
+# or through the Monitoring API v3 metricsScopes resource.
+# List the projects in the current project's metrics scope:
+curl -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+  "https://monitoring.googleapis.com/v1/locations/global/metricsScopes/PROJECT_ID"
+```
+
 **Exam tips:**
+- "Dashboards across all environments in one place" = a **metrics scope** with a dedicated scoping project. It is not a log sink, not an aggregated export, and not a shared VPC concern.
+- A metrics scope only covers **metrics**. Cross-project log centralisation is a separate mechanism, an **aggregated sink** at folder or organization level routing into a central log bucket.
 - Know which metric type to use: built-in for GCP services, custom for business metrics, Prometheus for K8s workloads.
 - Uptime checks run from *Google's infrastructure*, not your project -- they check external availability from the internet.
 - Alerting policy duration ("for 5 minutes") prevents flapping -- a single spike does not trigger an alert.
@@ -298,6 +369,9 @@ Resource groups let you organize monitored resources for collective dashboards a
 - [Uptime checks](https://cloud.google.com/monitoring/uptime-checks)
 - [Alerting policies](https://cloud.google.com/monitoring/alerts)
 - [Custom metrics](https://cloud.google.com/monitoring/custom-metrics)
+- [Metrics scopes](https://cloud.google.com/monitoring/settings)
+- [Monitoring quotas and limits](https://cloud.google.com/monitoring/quotas)
+- [Metric data retention](https://cloud.google.com/monitoring/api/v3/latency-n-retention)
 
 ---
 
@@ -320,7 +394,7 @@ Cloud Logging is the centralized log management service. It ingests, stores, rou
 | **Admin Activity** | Resource config changes (create, delete, update) | Yes, always on | `_Required` bucket (400 days, immutable) | Cannot be disabled or exempted |
 | **System Event** | Google-initiated system actions | Yes, always on | `_Required` bucket (400 days) | Cannot be disabled |
 | **Data Access** | Read resource config, read/write user data | No (except BigQuery) | `_Default` bucket (30 days) | Can exempt specific users/groups |
-| **Policy Denied** | Security policy violations | Yes, always on | `_Default` bucket (30 days) | Can exempt specific users/groups |
+| **Policy Denied** | Security policy violations | Yes, always on | `_Default` bucket (30 days) | No principal exemption. The only way to stop them is a Log Router exclusion filter |
 
 ```bash
 # View Admin Activity audit logs
@@ -575,7 +649,7 @@ sudo systemctl status google-cloud-ops-agent
 
 Cloud Trace is a distributed tracing system that collects latency data from applications. It helps identify bottlenecks in microservice architectures.
 
-- Automatically collects traces from App Engine, Cloud Run, and Cloud Functions
+- Automatically collects traces from App Engine, Cloud Run, and Cloud Run functions
 - Requires instrumentation (OpenTelemetry) for GKE, GCE, and other platforms
 - Shows end-to-end request latency across service boundaries
 - Identifies slow RPCs, database calls, and external API calls
@@ -617,7 +691,7 @@ Supports: Go, Java, Node.js, Python
 
 Error Reporting aggregates and displays errors from cloud services, automatically grouping similar errors.
 
-- Automatically works with App Engine, Cloud Functions, Cloud Run
+- Automatically works with App Engine, Cloud Run, and Cloud Run functions
 - Requires Logging integration for GCE and GKE (errors in logs are auto-detected)
 - Groups errors by stack trace similarity
 - Tracks error count, affected users, first/last occurrence
@@ -636,7 +710,7 @@ gcloud beta error-reporting events list --service=my-service --limit=10
 - **Cloud Trace = latency** (distributed tracing across microservices). Use when a question asks about "slow requests" or "identifying bottlenecks."
 - **Cloud Profiler = resource usage** (CPU, memory). Use when a question asks about "high CPU" or "memory leaks" in production.
 - **Error Reporting = error grouping** (aggregate and deduplicate). Use when a question asks about "tracking production errors" or "new error types."
-- Trace is automatic for App Engine/Cloud Run/Cloud Functions. For GKE/GCE, you need OpenTelemetry.
+- Trace is automatic for App Engine, Cloud Run and Cloud Run functions. For GKE/GCE, you need OpenTelemetry.
 - Profiler has negligible overhead and is safe for production. This is a key exam differentiator vs traditional profiling.
 
 **Docs:**
@@ -774,7 +848,7 @@ gcloud monitoring snoozes create \
 
 **Docs:**
 - [SLO burn rate alerting](https://cloud.google.com/stackdriver/docs/solutions/slo-monitoring/alerting-on-budget-burn-rate)
-- [Alerting best practices](https://cloud.google.com/monitoring/alerts/alerting-best-practices)
+- [Alerting on SLO burn rate](https://cloud.google.com/stackdriver/docs/solutions/slo-monitoring/alerting-on-budget-burn-rate)
 - [Notification channels](https://cloud.google.com/monitoring/support/notification-options)
 - [Snooze policies](https://cloud.google.com/monitoring/alerts/snooze)
 
@@ -784,7 +858,7 @@ gcloud monitoring snoozes create \
 
 ### Cloud Deploy
 
-Cloud Deploy is a managed continuous delivery service for GKE, Cloud Run, and Anthos. It follows a pipeline model with explicit promotion between environments.
+Cloud Deploy is a managed continuous delivery service for GKE, Cloud Run, and GKE Enterprise (formerly Anthos) clusters. It follows a pipeline model with explicit promotion between environments.
 
 #### Core Concepts
 
@@ -855,46 +929,30 @@ gke:
 requireApproval: true
 ```
 
+The lifecycle in four commands:
+
 ```bash
-# Register the pipeline and targets
+# Register the pipeline and targets from clouddeploy.yaml
 gcloud deploy apply --file=clouddeploy.yaml --region=us-central1
 
-# Create a release (triggered by CI/CD or manually)
+# Create an immutable release, pinning the image
 gcloud deploy releases create release-001 \
   --delivery-pipeline=my-app-pipeline \
   --region=us-central1 \
-  --images=my-app=gcr.io/PROJECT/my-app:v1.2.3
+  --images=my-app=us-central1-docker.pkg.dev/PROJECT/my-repo/my-app:v1.2.3
 
-# Promote a release to the next stage
-gcloud deploy releases promote \
-  --release=release-001 \
-  --delivery-pipeline=my-app-pipeline \
-  --region=us-central1
+# Move it to the next stage
+gcloud deploy releases promote --release=release-001 \
+  --delivery-pipeline=my-app-pipeline --region=us-central1
 
-# Approve a pending rollout
-gcloud deploy rollouts approve rollout-001 \
-  --release=release-001 \
-  --delivery-pipeline=my-app-pipeline \
-  --to-target=staging \
-  --region=us-central1
-
-# Check rollout status
-gcloud deploy rollouts list \
-  --release=release-001 \
-  --delivery-pipeline=my-app-pipeline \
-  --region=us-central1
-
-# Rollback: create a new release pointing to the previous image
-gcloud deploy releases create rollback-001 \
-  --delivery-pipeline=my-app-pipeline \
-  --region=us-central1 \
-  --images=my-app=gcr.io/PROJECT/my-app:v1.2.2
-
-# Or rollback a specific rollout
+# Roll a target back to its previous successful release
 gcloud deploy targets rollback prod \
-  --delivery-pipeline=my-app-pipeline \
-  --region=us-central1
+  --delivery-pipeline=my-app-pipeline --region=us-central1
 ```
+
+**Rollback is native.** `gcloud deploy targets rollback` creates a rollback rollout from the target's previously successful release, and automation rules can trigger it without a human. Do not accept "the only way to roll back Cloud Deploy is to cut a new release with the old image" -- that is a workaround, not the mechanism.
+
+**Deploy verification and deploy analysis are different mechanisms.** `verify: true` runs a Skaffold `verify` job, an arbitrary container that asserts the deployment works. **Deploy analysis** instead reads telemetry from Google Cloud Observability, or another monitoring provider, to judge whether a canary phase should advance, usually wired to an `advanceRolloutRule` automation. A question naming one and describing the other is a trap.
 
 ### Canary Deployments
 
@@ -919,7 +977,7 @@ strategy:
 ```bash
 # Deploy new revision without sending traffic
 gcloud run deploy my-service \
-  --image=gcr.io/PROJECT/my-app:v2 \
+  --image=us-central1-docker.pkg.dev/PROJECT/my-repo/my-app:v2 \
   --no-traffic \
   --region=us-central1
 
@@ -948,57 +1006,10 @@ gcloud run services update-traffic my-service \
 
 Blue-green maintains two identical production environments. Traffic is switched all at once from blue (current) to green (new).
 
-**On GKE:**
+**On GKE:** run two Deployments that differ only by a `version: blue` / `version: green` label, each at full replica count, and put that label in the Service selector. The Service selector is the switch.
+
 ```yaml
-# Blue deployment (current production)
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: my-app-blue
-  labels:
-    app: my-app
-    version: blue
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: my-app
-      version: blue
-  template:
-    metadata:
-      labels:
-        app: my-app
-        version: blue
-    spec:
-      containers:
-        - name: my-app
-          image: gcr.io/PROJECT/my-app:v1
----
-# Green deployment (new version, deployed alongside blue)
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: my-app-green
-  labels:
-    app: my-app
-    version: green
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: my-app
-      version: green
-  template:
-    metadata:
-      labels:
-        app: my-app
-        version: green
-    spec:
-      containers:
-        - name: my-app
-          image: gcr.io/PROJECT/my-app:v2
----
-# Service pointing to blue (switch selector to green to cutover)
+# The only line that decides which environment serves traffic
 apiVersion: v1
 kind: Service
 metadata:
@@ -1006,14 +1017,16 @@ metadata:
 spec:
   selector:
     app: my-app
-    version: blue   # Change to "green" to switch traffic
+    version: blue   # change to "green" to cut over
   ports:
     - port: 80
       targetPort: 8080
 ```
 
 Cutover: `kubectl patch svc my-app-svc -p '{"spec":{"selector":{"version":"green"}}}'`
-Rollback: `kubectl patch svc my-app-svc -p '{"spec":{"selector":{"version":"blue"}}}'`
+Rollback: the same patch with `blue`. That symmetry is the point -- rollback is the same cost as the rollout, which is why blue-green wins whenever "instant rollback" is the stated requirement.
+
+The trade-off to name in an answer: **2x infrastructure for the duration of the cutover**, and no help at all with database schema changes, which still have to be backward-compatible across both versions.
 
 ### GKE Rolling Updates
 
@@ -1035,7 +1048,7 @@ spec:
     spec:
       containers:
         - name: my-app
-          image: gcr.io/PROJECT/my-app:v2
+          image: us-central1-docker.pkg.dev/PROJECT/my-repo/my-app:v2
           readinessProbe:
             httpGet:
               path: /healthz
@@ -1053,25 +1066,9 @@ spec:
 - `maxUnavailable=1, maxSurge=0`: No extra resources needed, but 1 pod always unavailable
 - Higher values = faster rollouts but more disruption
 
-```bash
-# Check rollout status
-kubectl rollout status deployment/my-app
+The architect-level point is that a rolling update's rollback is **another rolling update** (`kubectl rollout undo`), so it takes as long as the rollout did. That is why "instant rollback" in a requirement rules out rolling updates and points at blue-green or traffic-split canary.
 
-# Rollback to previous version
-kubectl rollout undo deployment/my-app
-
-# Rollback to a specific revision
-kubectl rollout undo deployment/my-app --to-revision=3
-
-# View rollout history
-kubectl rollout history deployment/my-app
-
-# Pause a rollout (for canary-like manual verification)
-kubectl rollout pause deployment/my-app
-
-# Resume a paused rollout
-kubectl rollout resume deployment/my-app
-```
+A readiness probe is not optional here: without one, Kubernetes counts a pod as available as soon as it starts, and the rollout marches on through a broken version.
 
 ### Deployment Strategy Comparison
 
@@ -1108,7 +1105,8 @@ GCP does not have a native feature flag service. Common approaches:
 - [Cloud Deploy overview](https://cloud.google.com/deploy/docs)
 - [Cloud Deploy canary deployments](https://cloud.google.com/deploy/docs/deployment-strategies/canary)
 - [Cloud Run traffic management](https://cloud.google.com/run/docs/rollouts-rollbacks-traffic-migration)
-- [GKE deployment strategies](https://cloud.google.com/kubernetes-engine/docs/concepts/deployment-strategies)
+- [Application deployment and testing strategies](https://cloud.google.com/architecture/application-deployment-and-testing-strategies)
+- [Updating apps on GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/updating-apps)
 - [Kubernetes rolling updates](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment)
 
 ---
@@ -1162,24 +1160,27 @@ A good runbook includes:
 6. **Root cause investigation**: How to identify the underlying issue
 
 Example runbook entry:
-```markdown
-## Alert: High Error Rate (>1% 5xx responses)
 
-### Diagnostics
+```text
+ALERT: High error rate (>1% 5xx responses)
+
+DIAGNOSTICS
 1. Check error rate dashboard: [link]
-2. Check recent deployments: `gcloud deploy releases list --delivery-pipeline=PIPELINE --region=REGION`
+2. Check recent deployments:
+   gcloud deploy releases list --delivery-pipeline=PIPELINE --region=REGION
 3. Check Cloud Logging for error details:
-   `gcloud logging read 'severity="ERROR" AND resource.type="k8s_container"' --limit=50`
-4. Check pod status: `kubectl get pods -n production`
+   gcloud logging read 'severity="ERROR" AND resource.type="k8s_container"' --limit=50
+4. Check pod status:
+   kubectl get pods -n production
 
-### Mitigation
-1. If caused by recent deployment: rollback
-   `gcloud deploy targets rollback prod --delivery-pipeline=PIPELINE --region=REGION`
-2. If caused by load spike: scale up
-   `kubectl scale deployment my-app --replicas=20 -n production`
-3. If caused by downstream dependency: enable circuit breaker / fallback
+MITIGATION
+1. Caused by a recent deployment: roll the target back
+   gcloud deploy targets rollback prod --delivery-pipeline=PIPELINE --region=REGION
+2. Caused by a load spike: scale up
+   kubectl scale deployment my-app --replicas=20 -n production
+3. Caused by a downstream dependency: enable circuit breaker / fallback
 
-### Escalation
+ESCALATION
 - On-call SRE: [PagerDuty rotation link]
 - Service owner: @team-lead
 - VP escalation (P1 only): @vp-engineering
@@ -1218,19 +1219,18 @@ Action Items:
 - [ ] Load test with production-scale connection counts (@carol, 2026-03-07)
 ```
 
-### Google Cloud Support Tiers
+### Google Cloud Customer Care Tiers
 
-| Feature | Standard | Enhanced | Premium |
-|---------|----------|----------|---------|
-| **Price** | $29/mo min | 3% of monthly spend ($500 min) | Contact sales (high) |
-| **Response time (P1)** | 4 hours | 1 hour | 15 minutes |
-| **Response time (P2)** | 8 hours | 4 hours | 2 hours |
-| **Channels** | Web/chat | Web/chat/phone | Web/chat/phone |
-| **TAM** | No | No | Yes (named) |
-| **Training** | No | No | Yes |
-| **Advisory services** | No | No | Yes |
-| **Third-party support** | No | No | Yes |
-| **Active Assist** | No | Recommendations | Recommendations + review |
+Support tier selection is a real exam answer, not trivia: questions framed as "customer success" or "the business needs faster incident response" often resolve to buying a tier rather than building anything.
+
+| Feature | Basic | Standard | Enhanced | Premium |
+|---------|-------|----------|----------|---------|
+| **Cost** | Included | Higher of $29/month or 3% of monthly spend | Higher of $100/month or a tiered % (10% to $10K, 7% to $80K, 5% to $250K, 3% above) | Higher of $15,000/month or a tiered % (10% to $150K, 7% to $500K, 5% to $1M, 3% above) |
+| **Published response SLO** | None | P2 within 4 hours, local business hours | **P1 within 1 hour**, 24/7 | **P1 within 15 minutes**, 24/7 |
+| **TAM** | No | No | No | Yes, named |
+| **Best fit** | Billing and docs only | Non-production, small workloads | Production workloads needing 24/7 P1 cover | Enterprise, mission-critical, needs an advocate inside Google |
+
+The two numbers that decide most questions: **Enhanced buys a 1-hour P1 response, Premium buys 15 minutes and a TAM.** Everything else follows from those.
 
 #### Technical Account Managers (TAMs)
 
@@ -1251,7 +1251,10 @@ Action Items:
 **Docs:**
 - [Incident response process](https://sre.google/sre-book/managing-incidents/)
 - [Post-mortem culture](https://sre.google/sre-book/postmortem-culture/)
-- [Google Cloud Support](https://cloud.google.com/support/docs/premium-support)
+- [Cloud Customer Care](https://cloud.google.com/support)
+- [Standard Support](https://cloud.google.com/support/docs/standard)
+- [Enhanced Support](https://cloud.google.com/support/docs/enhanced)
+- [Premium Support](https://cloud.google.com/support/docs/premium)
 - [Runbooks and playbooks](https://sre.google/workbook/on-call/)
 
 ---
@@ -1373,7 +1376,7 @@ resource "google_monitoring_slo" "availability" {
 - SLA is always **less stringent** than SLO. The buffer is intentional -- it gives the team room to detect and fix issues before contractual penalties kick in.
 - Not every service needs an SLA. SLOs are internal targets; SLAs are external commitments.
 - The exam may ask you to identify the correct SLI for a scenario: availability for uptime, latency for response time, freshness for data pipelines.
-- 99.9% ("three nines") = 43.8 minutes of downtime per month. 99.99% ("four nines") = 4.38 minutes. Know these numbers.
+- Downtime figures in this file use a **30-day month (43,200 minutes)**, which is the basis Cloud Monitoring rolling-window SLOs use. On that basis 99.9% = 43.2 min/month and 99.99% = 4.32 min/month. Some vendor tables use an average 30.44-day month and print 43.8 and 4.38; both are the same SLO, only the window differs. Pick one basis and stay on it inside a calculation.
 
 **Docs:**
 - [SLO monitoring in Cloud Monitoring](https://cloud.google.com/stackdriver/docs/solutions/slo-monitoring)
@@ -1476,6 +1479,47 @@ Key insight: **Being too reliable is wasteful.** If you never consume your error
 
 ---
 
+### Composing SLOs Across Dependent Services
+
+A service cannot be more available than the things it must call. This is the calculation the exam reaches for whenever a stem lists component SLAs and asks what the composite service can promise.
+
+**Serial dependencies (every component must work): multiply.**
+
+```
+Composite availability = A1 * A2 * ... * An
+```
+
+| Chain | Arithmetic | Composite |
+|-------|-----------|-----------|
+| ALB 99.99% + GKE regional 99.95% + Cloud SQL HA 99.95% | 0.9999 * 0.9995 * 0.9995 | ~99.89% |
+| Four components at 99.9% each | 0.999^4 | ~99.6% |
+| Ten components at 99.99% each | 0.9999^10 | ~99.9% |
+
+The result is always **lower than the weakest link**, which is the trap. Adding a dependency can only reduce availability, so "we added a caching tier and the SLO improved" is wrong unless the cache also removes a dependency from the critical path.
+
+**Redundant dependencies (any one is enough): multiply the failure rates.**
+
+```
+Composite unavailability = U1 * U2
+```
+
+Two independent 99.9% regions behind a global load balancer give 0.001 * 0.001 = 0.000001, so ~99.9999% -- but only if the failures are genuinely independent. A shared regional control plane, a shared database, or a single deployment pipeline pushing the same bad build to both makes the failures correlated and the arithmetic invalid.
+
+**Setting the internal SLO.** Work backwards: if the user-facing SLO is 99.9% and three internal services sit in series, each needs roughly 99.97% for the composite to clear the target with any margin left for the service's own code. That is why platform and shared services carry stricter SLOs than the products on top of them.
+
+**Exam tips:**
+- Serial = multiply availabilities. Parallel/redundant = multiply unavailabilities. Getting the two the wrong way round is the most common error on these items.
+- A composite SLA is **always worse than its worst component** in a serial chain. If an option shows a composite higher than every input, it is wrong on inspection.
+- Redundancy only pays off when the failures are independent. Look for a shared dependency in the stem before accepting the parallel arithmetic.
+- The *dependency's* SLA is a ceiling on what you can promise, so promising 99.99% on top of a 99.95% managed service is not achievable no matter how good your code is.
+
+**Docs:**
+- [Defining SLOs](https://cloud.google.com/architecture/defining-SLOs)
+- [Patterns for scalable and resilient apps](https://cloud.google.com/architecture/scalable-and-resilient-apps)
+- [SRE Workbook: Implementing SLOs](https://sre.google/workbook/implementing-slos/)
+
+---
+
 ### Capacity Planning
 
 Capacity planning ensures your infrastructure can handle current and future load.
@@ -1568,7 +1612,7 @@ kubectl autoscale deployment my-app --cpu-percent=60 --min=3 --max=20
 - [Compute Engine autoscaling](https://cloud.google.com/compute/docs/autoscaler)
 - [Predictive autoscaling](https://cloud.google.com/compute/docs/autoscaler/predictive-autoscaling)
 - [GKE autoscaling](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler)
-- [Capacity planning](https://cloud.google.com/architecture/capacity-planning-and-management)
+- [Well-Architected Framework: Reliability](https://cloud.google.com/architecture/framework/reliability)
 
 ---
 
@@ -1588,10 +1632,12 @@ Chaos engineering is the practice of intentionally introducing failures to test 
 
 #### Fault Injection Testing on GCP
 
-**With Istio / Anthos Service Mesh:**
+**With Cloud Service Mesh** (the current name for both Anthos Service Mesh and Traffic Director), using the Istio API:
+
 ```yaml
-# VirtualService with fault injection
-apiVersion: networking.istio.io/v1alpha3
+# VirtualService with fault injection. The Istio networking API graduated to v1
+# in Istio 1.22; networking.istio.io/v1alpha3 is stale.
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: my-service
@@ -1662,7 +1708,7 @@ Common Game Day scenarios:
 | **Litmus** | CNCF chaos engineering framework for Kubernetes |
 | **Chaos Mesh** | Kubernetes-native chaos engineering platform |
 | **Gremlin** | SaaS chaos engineering platform (commercial) |
-| **Pod fault injection** | Native Istio/ASM fault injection |
+| **Pod fault injection** | Native Cloud Service Mesh fault injection |
 | **Compute Engine simulate-maintenance** | Test live migration behavior |
 
 ```bash
@@ -1676,12 +1722,13 @@ gcloud compute instances simulate-maintenance-event INSTANCE_NAME \
 **Exam tips:**
 - Chaos engineering is about **proactive reliability** -- finding failures before users do.
 - PodDisruptionBudgets (PDBs) protect against over-aggressive chaos (and normal maintenance). Know `minAvailable` and `maxUnavailable`.
-- Istio/ASM fault injection is the GCP-native way to inject faults. No extra tools needed.
+- Cloud Service Mesh fault injection is the Google Cloud native way to inject faults. No extra tools needed. Anthos Service Mesh and Traffic Director were both folded into this one product name.
 - Game Days are the organizational practice; chaos engineering is the technical practice. Both are valid exam answers.
 - `simulate-maintenance-event` tests VM live migration behavior -- important for latency-sensitive workloads.
 
 **Docs:**
-- [Chaos engineering on Google Cloud](https://cloud.google.com/architecture/framework/reliability/test-recovery)
+- [Testing for recovery from failures](https://cloud.google.com/architecture/framework/reliability/perform-testing-for-recovery-from-failures)
+- [Cloud Service Mesh](https://cloud.google.com/service-mesh/docs/overview)
 - [Istio fault injection](https://istio.io/latest/docs/tasks/traffic-management/fault-injection/)
 - [PodDisruptionBudgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/)
 - [Simulate maintenance events](https://cloud.google.com/compute/docs/instances/simulating-host-maintenance)
@@ -1693,7 +1740,7 @@ gcloud compute instances simulate-maintenance-event INSTANCE_NAME \
 #### Google Cloud Penetration Testing Policy
 
 Google Cloud **allows** penetration testing on your own resources without prior approval. Key rules:
-- You CAN pen-test your own VMs, containers, App Engine apps, Cloud Functions, etc.
+- You CAN pen-test your own VMs, containers, App Engine apps, Cloud Run functions, etc.
 - You CANNOT pen-test Google's underlying infrastructure
 - You MUST stay within your own project boundaries
 - No need to notify Google beforehand (unlike some other cloud providers)
@@ -1714,8 +1761,10 @@ Web Security Scanner is a built-in tool that scans App Engine, GKE, and Compute 
 ```
 
 Scan types:
-- **Managed scans**: Automatically scan App Engine and Cloud Run apps weekly
-- **Custom scans**: Configure target URLs, authentication, schedule
+- **Managed scans**: configured and run by Security Command Center once a week, on Premium and Enterprise tiers. They discover public web endpoints, send GET requests only, and use default ports (80/443) only
+- **Custom scans**: project-level, user-defined target URLs, authentication, schedule and non-default ports
+
+**Exam trap:** the supported targets are **App Engine, GKE and Compute Engine only**. Cloud Run is not supported by Web Security Scanner, so an option pairing the two is wrong.
 
 #### Security Command Center (SCC)
 
@@ -1845,8 +1894,8 @@ kubectl scale deployment locust-worker --replicas=20
 
 **Docs:**
 - [Distributed load testing on GKE](https://cloud.google.com/architecture/distributed-load-testing-using-gke)
-- [Load testing Cloud Run](https://cloud.google.com/run/docs/testing/load-testing)
-- [Performance testing best practices](https://cloud.google.com/architecture/framework/performance-optimization/testing)
+- [Distributed load testing using GKE](https://cloud.google.com/architecture/distributed-load-testing-using-gke)
+- [Well-Architected Framework: Performance Optimization](https://cloud.google.com/architecture/framework/performance-optimization)
 
 ---
 
@@ -1910,10 +1959,19 @@ gcloud container clusters update my-cluster \
   --remove-maintenance-exclusion=holiday-freeze
 ```
 
-Maintenance exclusion scopes:
-- `no_upgrades`: No control plane or node upgrades
-- `no_minor_upgrades`: Patch upgrades allowed, minor version upgrades blocked
-- `no_minor_or_node_upgrades`: Only control plane patch upgrades allowed
+Maintenance exclusion scopes, with the limits that actually get tested:
+
+| Scope | What It Blocks | Maximum Duration |
+|-------|----------------|------------------|
+| `no_upgrades` | All control plane and node upgrades | **90 days** |
+| `no_minor_upgrades` | Minor version upgrades; patches still apply | Until end of support for the minor version |
+| `no_minor_or_node_upgrades` | Minor upgrades and all node upgrades; control plane patches still apply | Until end of support for the minor version |
+
+Additional rules:
+
+- Exclusions must leave at least **48 hours of maintenance availability in any 92-day rolling window**, so a `no_upgrades` exclusion cannot be chained to block upgrades forever.
+- At most **three `no_upgrades` exclusions** per cluster, and up to **20 exclusions** in total.
+- Google's own recommendation is to keep `no_upgrades` under 30 days so security patches are not deferred.
 
 #### GKE Node Upgrade Strategies
 
@@ -1996,7 +2054,7 @@ VM Manager provides automated OS patch management for Compute Engine VMs.
 ```bash
 # Enable VM Manager (OS Config agent)
 gcloud compute project-info add-metadata \
-  --metadata=enable-os-config=TRUE
+  --metadata=enable-osconfig=TRUE
 
 # Create a patch deployment (recurring)
 gcloud compute os-config patch-deployments create weekly-patches \
@@ -2036,7 +2094,7 @@ gcloud compute os-config patch-jobs describe JOB_ID
 **Exam tips:**
 - **GKE release channels**: Regular is the default and recommended for most production. Stable is for regulated industries. Extended is for version pinning.
 - Maintenance windows define *when* upgrades can happen, not *if*. GKE will still auto-upgrade -- just within your window.
-- Maintenance exclusions cannot exceed 180 days for `no_upgrades` scope.
+- Maintenance exclusions with the `no_upgrades` scope cap at 90 days, and must leave 48 hours of maintenance availability in every 92-day rolling window.
 - **Blue-green node pool upgrade** is the safest GKE upgrade strategy but costs 2x during the upgrade window.
 - Cloud SQL HA instances failover during maintenance, reducing downtime. This is a common exam justification for HA configuration.
 - VM Manager / OS Config is the answer for "how to patch VMs at scale." Do not confuse with manual SSH + `apt-get upgrade`.
@@ -2049,7 +2107,8 @@ gcloud compute os-config patch-jobs describe JOB_ID
 - [GKE node upgrade strategies](https://cloud.google.com/kubernetes-engine/docs/concepts/node-pool-upgrade-strategies)
 - [Cloud SQL maintenance](https://cloud.google.com/sql/docs/mysql/maintenance)
 - [MIG rolling updates](https://cloud.google.com/compute/docs/instance-groups/rolling-out-updates-to-managed-instance-groups)
-- [VM Manager OS patch management](https://cloud.google.com/compute/docs/os-patch-management)
+- [VM Manager](https://cloud.google.com/compute/docs/vm-manager)
+- [Enabling the OS Config agent](https://cloud.google.com/compute/docs/manage-os)
 - [PodDisruptionBudgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
 
 ---
@@ -2066,6 +2125,8 @@ Question about observability?
 ├── "How to route logs to BigQuery?"       --> Log Router sink
 ├── "How to reduce logging costs?"         --> Exclusion filters on _Default sink
 ├── "How to monitor K8s with Prometheus?"  --> Managed Service for Prometheus (GMP)
+├── "One dashboard across many projects?"  --> Metrics scope with a dedicated scoping project
+├── "Central logs across an org?"          --> Aggregated sink at folder/org level
 └── "How to collect VM logs/metrics?"      --> Ops Agent
 
 Question about deployment?
@@ -2084,6 +2145,9 @@ Question about reliability?
 ├── "How to alert on reliability?"         --> SLO burn rate alerting
 ├── "How to test resilience?"              --> Chaos engineering / Game Days
 ├── "How to handle post-incident?"         --> Blameless post-mortem
+├── "Composite SLA of a serial chain?"     --> Multiply the availabilities
+├── "Availability of a redundant pair?"    --> Multiply the unavailabilities
+├── "How fast is our delivery improving?"  --> DORA metrics, not SLOs
 └── "How to upgrade GKE safely?"           --> Release channels + maintenance windows + PDBs
 
 Question about support?
@@ -2107,7 +2171,12 @@ Question about support?
 | "Blue-green is always better than canary" | Blue-green costs 2x. Canary is cheaper and catches issues early. Choose based on requirements. |
 | "You need Google permission for pen testing" | No prior approval needed for testing your own resources. |
 | "Cloud Trace and Cloud Profiler do the same thing" | Trace = distributed request latency across services. Profiler = CPU/memory within a single service. |
-| "Maintenance exclusions stop all upgrades forever" | Maximum 180 days for `no_upgrades` scope. Cannot indefinitely block. |
+| "Maintenance exclusions stop all upgrades forever" | `no_upgrades` caps at 90 days, and 48 hours of maintenance must stay available in every 92-day rolling window. |
 | "Ops Agent is only for logging" | Ops Agent handles BOTH logging AND metrics collection. It replaces both legacy agents. |
 | "Uptime checks run from your VMs" | They run from Google's global infrastructure, checking your service externally. |
 | "Feature freeze is a punishment" | It is a data-driven response to exhausted error budget, not punitive. |
+| "Log-based metrics are retained like other metrics" | Log-based metrics keep 6 weeks. Most Google Cloud and custom metrics keep 24 months. Longer horizons need a log bucket or BigQuery. |
+| "Web Security Scanner covers Cloud Run" | Supported targets are App Engine, GKE and Compute Engine only. |
+| "Policy Denied audit logs can exempt a principal" | No principal exemption exists. Only a Log Router exclusion filter suppresses them. |
+| "A composite SLA can beat its weakest component" | In a serial chain it never can. Availabilities multiply, so the result is always lower. |
+| "Cloud Deploy has no rollback, you re-release" | `gcloud deploy targets rollback` is native, and automation rules can fire it. |

--- a/gcp/pca/docs/07-well-architected-framework.md
+++ b/gcp/pca/docs/07-well-architected-framework.md
@@ -54,15 +54,15 @@ The PCA exam tests your ability to **evaluate architecture trade-offs**. Almost 
 
 Operational Excellence focuses on running, monitoring, and continuously improving systems. Google Cloud's approach to this pillar is heavily influenced by **Site Reliability Engineering (SRE)** practices.
 
-**Core principles:**
+**Google's five published principles**, which is the wording an exam item may quote:
 
-1. **Define clear SLOs, SLIs, and SLAs** -- Measure what matters to users, not just infrastructure metrics
-2. **Automate everything possible** -- Reduce toil (repetitive, manual, automatable work) to free engineering time for innovation
-3. **Monitor proactively, not reactively** -- Use observability (metrics, logs, traces) to detect issues before users notice
-4. **Practice incident management** -- Establish clear on-call rotations, runbooks, escalation paths, and blameless post-mortems
-5. **Embrace change management** -- Use CI/CD pipelines, IaC, and progressive rollouts to deploy safely
-6. **Manage capacity proactively** -- Use autoscaling and quota management to handle demand fluctuations
-7. **Build for operability from day one** -- Design systems that are easy to deploy, debug, and maintain
+1. **Ensure operational readiness and performance using CloudOps** -- define SLOs, instrument for observability, test before launch, plan capacity
+2. **Manage incidents and problems** -- detect, respond, mitigate, then run retrospectives and close the preventive actions
+3. **Manage and optimize cloud resources** -- right-size, autoscale, and treat cost as an operational signal
+4. **Automate and manage change** -- IaC, CI/CD, progressive rollouts, and a change process that makes rollback cheap
+5. **Continuously improve and innovate** -- feed operational learning back into design
+
+The SRE vocabulary that sits underneath -- SLOs and error budgets, toil, blameless post-mortems, golden signals -- is supporting material, not the principle list. Section 6 covers it in depth.
 
 ### SLOs, SLIs, and SLAs Deep Dive
 
@@ -99,7 +99,7 @@ Error Budget   = 0.1% = ~43.2 minutes of downtime per 30 days
 | **Cloud Deploy** | Managed continuous delivery to GKE/Cloud Run | Delivery pipelines, approval gates, rollbacks |
 | **Cloud Build** | CI/CD build automation | Build triggers, custom builders, SLSA compliance |
 | **Artifact Registry** | Artifact/container image management | Vulnerability scanning, cleanup policies, remote repos |
-| **Service Mesh (Istio/Anthos)** | Traffic management, observability | Canary deployments, circuit breaking, mTLS |
+| **Cloud Service Mesh** | Traffic management, observability | Canary deployments, circuit breaking, mTLS. Absorbed both Anthos Service Mesh and Traffic Director |
 | **Cloud Scheduler** | Managed cron job service | HTTP/Pub/Sub/App Engine targets |
 | **Cloud Tasks** | Asynchronous task execution | Rate limiting, retry policies, task deduplication |
 | **Recommender** | AI-powered operational recommendations | Idle resource detection, rightsizing, security insights |
@@ -175,7 +175,7 @@ gcloud projects set-iam-policy my-project policy.json
 gcloud deploy releases create release-001 \
   --delivery-pipeline=my-pipeline \
   --region=us-central1 \
-  --images=my-app=gcr.io/my-project/my-app:v1.2.3
+  --images=my-app=us-central1-docker.pkg.dev/my-project/my-repo/my-app:v1.2.3
 
 # Promote a release to the next stage
 gcloud deploy releases promote \
@@ -219,13 +219,14 @@ Post-mortem template key sections:
 
 - **SLO vs SLA**: If a question asks about setting reliability targets that the engineering team uses internally, it is an **SLO**. If it involves a customer contract with financial penalties, it is an **SLA**. SLOs should always be stricter than SLAs.
 - **Error budget exhaustion**: When error budget is depleted, the correct action is to **freeze feature releases and focus on reliability** -- not to lower the SLO.
-- **Cloud Operations Suite**: Know that Cloud Monitoring, Cloud Logging, Cloud Trace, Cloud Profiler, and Error Reporting collectively form the **Cloud Operations Suite** (formerly Stackdriver).
+- **Google Cloud Observability**: Cloud Monitoring, Cloud Logging, Cloud Trace, Cloud Profiler and Error Reporting collectively form **Google Cloud Observability**, which was called the Cloud Operations Suite and, before that, Stackdriver.
 - **Log Router**: Questions about sending logs to different destinations (BigQuery for analysis, Cloud Storage for archival, Pub/Sub for streaming) test your knowledge of the **Log Router** with inclusion/exclusion filters.
 - **Audit logs**: Admin Activity logs are **always enabled and free**. Data Access logs must be **explicitly enabled** and can generate significant volume/cost.
 - **Managed Prometheus**: For GKE monitoring, Google recommends **Managed Service for Prometheus** -- it is the successor to legacy Stackdriver Kubernetes monitoring.
 - **Deployment strategy selection**: If the question emphasizes "minimize risk" or "gradual rollout," the answer is usually **canary deployment**. If it says "instant rollback," think **blue/green**.
 
 **Docs:** [Operational Excellence](https://cloud.google.com/architecture/framework/operational-excellence)
+**Docs:** [Operational excellence principles](https://cloud.google.com/architecture/framework/operational-excellence/principles)
 **Docs:** [Cloud Monitoring](https://cloud.google.com/monitoring/docs)
 **Docs:** [Cloud Logging](https://cloud.google.com/logging/docs)
 **Docs:** [Cloud Deploy](https://cloud.google.com/deploy/docs)
@@ -471,7 +472,7 @@ gcloud access-context-manager perimeters create my-perimeter \
 | Context-aware access | **Access Context Manager** | Conditional access based on context |
 | Micro-segmentation | **VPC Firewall Rules / Policies** | East-west traffic control |
 | Service identity | **Workload Identity** | Kubernetes pod identity |
-| mTLS | **Traffic Director / Anthos Service Mesh** | Service-to-service encryption |
+| mTLS | **Cloud Service Mesh** | Service-to-service encryption |
 
 ```bash
 # Enable IAP for a backend service (replaces VPN)
@@ -564,7 +565,7 @@ Global failure: Extremely rare             → Accept the risk or use multi-clou
 | **GKE Regional Cluster** | Control plane in 3 zones, nodes across zones | Pod rescheduling, node auto-repair |
 | **Cloud Run** | Automatically regional | Transparent zone failover |
 | **App Engine** | Automatically regional | Automatic scaling and healing |
-| **Cloud Functions** | Automatically regional | Transparent zone failover |
+| **Cloud Run functions** | Automatically regional | Transparent zone failover |
 
 #### Highly Available Storage and Databases
 
@@ -626,9 +627,12 @@ gcloud spanner instances create my-instance \
   --processing-units=1000 \
   --description="Multi-region North America"
 
-# nam14 = replicas in us-central1, us-central2, us-east1, us-east4
+# nam14 = read-write replicas in us-east4 (default leader) and northamerica-northeast1,
+#         with a witness replica in us-east1
 # Automatic failover, zero RPO, near-zero RTO
 ```
+
+Multi-region configs always follow the same shape: **two read-write regions plus a witness region**. The witness holds no data, it only votes in the quorum, which is what lets the configuration survive losing a read-write region without losing writes. An option describing a multi-region config as "N full copies across N regions" has the model wrong.
 
 #### RPO/RTO Calculation Guide
 
@@ -661,8 +665,8 @@ Cost: $     ← Backup & Restore (only storage costs in DR region)
 | **Chaos Monkey** (Netflix OSS) | Random instance termination | Run on GKE to kill pods |
 | **Litmus Chaos** | Kubernetes-native chaos | GKE, pod/node failures, network chaos |
 | **gcloud compute instances stop** | Zone failure simulation | Manually stop VMs in a zone |
-| **Network fault injection** | Latency, packet loss | Istio/Envoy fault injection, Traffic Director |
-| **Load testing** | Capacity limits | Cloud Load Testing (deprecated), Locust on GKE |
+| **Network fault injection** | Latency, packet loss | Cloud Service Mesh fault injection (Istio/Envoy) |
+| **Load testing** | Capacity limits | Locust or k6, run distributed on GKE. There is no Google-managed load testing service |
 
 ```bash
 # Simulate zone failure: stop all instances in a zone
@@ -712,7 +716,7 @@ Region A (us-central1)              Region B (us-east1)
 ### Exam Tips
 
 - **Cloud SQL HA is NOT multi-region**: Regional HA with a standby in a different zone is automatic failover within ONE region. Cross-region requires read replicas with manual promotion.
-- **Spanner multi-region configs**: Know the named configs -- `nam14` (North America), `eur6` (Europe), `nam-eur-asia1` (global). These provide zero RPO and automatic failover.
+- **Spanner multi-region configs**: know the named configs -- `nam3` and `nam14` (North America), `eur6` (Europe), `nam-eur-asia1` (global). Each has two read-write regions and a witness region, giving zero RPO and automatic failover. `nam14`: read-write in `us-east4` (default leader) and `northamerica-northeast1`, witness in `us-east1`. `eur6`: read-write in `europe-west4` (default leader) and `europe-west3`, witness in `europe-west6`.
 - **Cloud Storage classes and availability**: the SLA depends on **class and location together**, not class alone. Standard is 99.95% in multi-region or dual-region and 99.9% in a single region. Nearline, Coldline and Archive are 99.9% in multi-region or dual-region and 99.0% in a single region. Archive is NOT slower to read -- it has millisecond first-byte latency like the rest, and its cost is in retrieval charges plus a 365-day minimum storage duration.
 - **Global vs Regional Load Balancer**: If the question mentions multi-region backend or anycast IP, the answer is **global**. If it mentions data sovereignty or single-region, the answer is **regional**.
 - **GKE regional cluster**: The control plane runs in 3 zones automatically. Node pools can be single-zone or multi-zone. For HA, always use **regional clusters with multi-zone node pools**.
@@ -807,7 +811,7 @@ gcloud recommender recommendations list \
 | **Cloud Storage Lifecycle** | Automatic storage class transitions | Nearline (30d) → Coldline (90d) → Archive (365d) |
 | **Preemptible/Spot Node Pools** | Cost-effective GKE nodes | Ideal for batch processing, CI/CD runners |
 | **BigQuery Editions** | Capacity-based pricing with autoscaling | Standard, Enterprise, Enterprise Plus editions |
-| **Cloud Functions / Cloud Run** | Pay-per-invocation/request | Zero cost when idle |
+| **Cloud Run and Cloud Run functions** | Pay-per-request or per-invocation | Zero cost when idle |
 | **Committed Use Discounts** | Reserved capacity discounts | Resource-based and spend-based options |
 
 ### Architect-Level Considerations
@@ -863,10 +867,13 @@ gcloud sql instances patch my-instance \
 |-------------|------|
 | **Ingress** (data into GCP) | **Free** |
 | **Egress** to internet | $0.08-$0.23/GB (tiered, decreases with volume) |
-| **Egress** between regions (same continent) | $0.01/GB |
-| **Egress** between regions (intercontinental) | $0.02-$0.08/GB |
+| **Egress** between regions, North America to North America | $0.02/GiB |
+| **Egress** between regions, Asia to Asia | $0.08/GiB |
+| **Egress** between regions, North America to or from Europe | $0.05/GiB |
+| **Egress** between regions, to or from Australia or Indonesia | $0.10/GiB |
+| **Egress** between regions, to or from South America | $0.14/GiB |
 | **Egress** within same zone | Free (internal IPs) |
-| **Egress** within same region, different zones | $0.01/GB |
+| **Egress** within same region, different zones | $0.01/GiB |
 | **Private Google Access** | Free (within same region) |
 | **Cloud Interconnect** egress | $0.02/GB (vs $0.08-$0.23 for internet) |
 
@@ -876,6 +883,8 @@ gcloud sql instances patch my-instance \
 - Use **Cloud Interconnect** or **Partner Interconnect** for high-volume data transfer (lower egress rates)
 - Use **Transfer Appliance** for large one-time migrations (>20 TB)
 - Use **Cloud Storage Transfer Service** for scheduled cross-cloud or cross-region transfers
+
+**Docs:** [VPC network pricing](https://cloud.google.com/vpc/network-pricing) | [Inter-region data transfer rates](https://cloud.google.com/vpc/pricing-announce)
 
 #### Storage Cost Optimization
 
@@ -930,7 +939,7 @@ gcloud billing budgets create \
   --notifications-rule-pubsub-topic=projects/my-project/topics/budget-alerts
 
 # Note: Budgets DO NOT stop spending! They only alert.
-# To stop spending, use Pub/Sub + Cloud Functions to disable billing:
+# To stop spending, use Pub/Sub + Cloud Run functions to disable billing:
 # 1. Budget alert → Pub/Sub topic
 # 2. Cloud Function triggered by Pub/Sub
 # 3. Function calls billing API to disable billing on the project
@@ -938,11 +947,11 @@ gcloud billing budgets create \
 
 ### Exam Tips
 
-- **Budgets do NOT stop spending**: This is a classic exam trap. Budgets only send alerts. To actually stop spending, you must automate billing disabling via Cloud Functions triggered by budget Pub/Sub notifications.
+- **Budgets do NOT stop spending**: This is a classic exam trap. Budgets only send alerts. To actually stop spending, you must automate billing disabling via Cloud Run functions triggered by budget Pub/Sub notifications.
 - **SUDs are automatic**: You do NOT need to configure SUDs. They apply automatically when a VM runs for more than 25% of a month. CUDs require explicit commitment.
 - **CUD flexibility**: Resource-based CUDs can be shared across projects in the same billing account. They apply to the most expensive eligible VMs first (to maximize your savings).
 - **Spot VMs for batch**: If a question mentions batch processing, ML training, or CI/CD and asks for the cheapest option, **Spot VMs** are almost always correct. They are not suitable for serving live traffic.
-- **Serverless for variable workloads**: Cloud Functions and Cloud Run scale to zero, meaning you pay nothing when there is no traffic. For unpredictable or spiky workloads, serverless is the most cost-effective option.
+- **Serverless for variable workloads**: Cloud Run and Cloud Run functions scale to zero, meaning you pay nothing when there is no traffic. For unpredictable or spiky workloads, serverless is the most cost-effective option.
 - **Cloud Storage class trap**: Archive class is NOT slower to retrieve. It has the same latency as other classes. The cost difference is in storage price (lowest) vs retrieval price (highest) and minimum storage duration (365 days).
 - **BigQuery pricing**: On-demand = $6.25/TB scanned. Enterprise editions = capacity-based with autoscaling slots. For predictable, heavy query workloads, editions with commitments are cheaper.
 - **Data locality = cost savings**: Always co-locate compute and storage in the same region. Cross-region data transfer adds cost.
@@ -981,7 +990,7 @@ Performance optimization ensures that resources are used efficiently to meet sys
 | Full VM control, custom software | **Compute Engine** | Full OS access, any software stack |
 | Containerized microservices, high scale | **GKE Autopilot** | Managed Kubernetes, auto-scaling, auto-provisioning |
 | HTTP services, rapid scaling | **Cloud Run** | Container-based, scales to zero, per-request pricing |
-| Event-driven, lightweight functions | **Cloud Functions** | Function-based, per-invocation, auto-scaling |
+| Event-driven, lightweight functions | **Cloud Run functions** | Function-based, per-invocation, auto-scaling |
 | Legacy apps, minimal refactoring | **App Engine (Standard/Flexible)** | PaaS, managed runtime, auto-scaling |
 | ML training (large models) | **Compute Engine + GPUs/TPUs** or **Vertex AI Training** | Accelerator access, distributed training |
 | ML inference (serving) | **Vertex AI Endpoints** or **GKE + GPUs** | Auto-scaling inference, model versioning |
@@ -1009,7 +1018,7 @@ Performance optimization ensures that resources are used efficiently to meet sys
 | **Standard Network Tier** | Public internet routing | Higher latency, lower cost |
 | **Cloud Interconnect** | Dedicated/partner connections to GCP | 10-200 Gbps, private connectivity, lower latency |
 | **Cloud DNS** | Managed authoritative DNS | 100% SLA, anycast, DNSSEC support |
-| **Traffic Director** | Global traffic management for service mesh | Load balancing across regions, traffic splitting |
+| **Cloud Service Mesh** | Global traffic management for service mesh, the product Traffic Director became | Load balancing across regions, traffic splitting |
 | **Network Endpoint Groups (NEGs)** | Fine-grained load balancing targets | Container-native LB (bypasses kube-proxy for lower latency) |
 
 #### Database Performance
@@ -1113,7 +1122,7 @@ gcloud container clusters update my-cluster \
 | **GKE Cluster Autoscaler** | Kubernetes nodes | Pending pods that cannot be scheduled | Node pool capacity |
 | **GKE Node Auto-provisioning (NAP)** | Kubernetes node pools | Workload requirements | Automatic node pool creation |
 | **Cloud Run** | Container instances | Concurrent requests | HTTP services |
-| **Cloud Functions** | Function instances | Incoming events | Event-driven workloads |
+| **Cloud Run functions** | Function instances | Incoming events | Event-driven workloads |
 | **Bigtable Autoscaler** | Bigtable nodes | CPU utilization, storage utilization | Time-series, IoT data |
 | **Spanner Autoscaler** | Processing units | CPU utilization | Globally distributed DB |
 
@@ -1235,7 +1244,7 @@ Sustainability is about minimizing the environmental impact of cloud workloads. 
 |---------|-------------------|--------|
 | **Carbon Footprint Dashboard** | Gross and market-based carbon emissions per project, region, service | Visibility into environmental impact |
 | **Active Assist Sustainability Recommendations** | Identifies workloads that could be moved to lower-carbon regions | Actionable region migration suggestions |
-| **Cloud Run / Cloud Functions** | Scale to zero | Zero energy when idle |
+| **Cloud Run and Cloud Run functions** | Scale to zero | Zero energy when idle |
 | **GKE Autopilot** | Efficient bin-packing of pods | Less wasted node capacity |
 | **Autoscaling (all services)** | Match capacity to demand | No idle over-provisioning |
 | **Cloud Storage Lifecycle Policies** | Automatic data deletion and class transitions | Reduced storage footprint |
@@ -1273,7 +1282,7 @@ Candidate regions:
 
 **Pattern 1: Serverless-First Architecture (Maximize Scale-to-Zero)**
 ```
-Cloud Run (scale to zero) → Cloud Functions (event processing) → BigQuery (serverless analytics)
+Cloud Run (scale to zero) → Cloud Run functions (event processing) → BigQuery (serverless analytics)
                          ↓
                     Firestore (serverless database)
 
@@ -1392,10 +1401,10 @@ Answer: B
 | "real-time analytics" | BigQuery streaming, Bigtable, Pub/Sub + Dataflow |
 | "batch processing, cost-sensitive" | Batch with Spot VMs, Dataflow Flex Templates |
 | "ML training at scale" | Vertex AI Training + GPUs/TPUs, distributed training |
-| "unpredictable traffic" | Cloud Run, Cloud Functions, App Engine auto-scaling |
+| "unpredictable traffic" | Cloud Run, Cloud Run functions, App Engine autoscaling |
 | "hybrid connectivity" | Cloud Interconnect (high bandwidth) or HA VPN (lower bandwidth) |
 | "legacy application" | App Engine Flexible, Compute Engine, or GKE with lift-and-shift containers |
-| "multi-cloud" | Anthos, BigQuery Omni, GKE Enterprise multi-cloud |
+| "multi-cloud" | GKE Enterprise multi-cloud, BigQuery Omni, Cloud Service Mesh |
 | "CI/CD pipeline" | Cloud Build + Cloud Deploy + Artifact Registry |
 | "secrets management" | Secret Manager (NOT KMS -- KMS is for encryption keys) |
 
@@ -1483,7 +1492,7 @@ T - Technology: Is this the right service for the job? (Decision tree)
 
 | Pillar | One-Liner | Key GCP Services | Top Exam Trap |
 |--------|-----------|-------------------|---------------|
-| **Operational Excellence** | Run it, monitor it, improve it | Cloud Ops Suite, Cloud Deploy, Cloud Build | SLO != SLA; error budgets drive release decisions |
+| **Operational Excellence** | Run it, monitor it, improve it | Google Cloud Observability, Cloud Deploy, Cloud Build | SLO != SLA; error budgets drive release decisions |
 | **Security** | Protect everything, trust nothing | IAM, VPC-SC, KMS, SCC, Binary Auth | VPC-SC != Firewall; Org Policy != IAM |
 | **Reliability** | Design for failure at every layer | Global LB, Spanner, GKE regional, Cloud SQL HA | Cloud SQL HA is NOT multi-region; RPO=0 needs sync replication |
 | **Cost Optimization** | Pay only for what you need | Recommender, Spot VMs, CUDs, lifecycle policies | Budgets do NOT stop spending; Archive is NOT slow |


### PR DESCRIPTION
## Summary

Errata for `docs/05-managing-implementations.md`, `docs/06-solution-operations-excellence.md` and `docs/07-well-architected-framework.md`. Part of a five-lane sweep clearing the backlog in `.claude/state/research/2026-08-09-pca-content-audit.md`.

Net line count is down (496 added, 582 removed) because ~500 lines of CLI and client-library dumps were compressed to the decisions they encode.

## Two dead sections rebuilt

- **Migrate to Containers.** The `migctl` and processing-cluster flow was removed by Google on 2024-05-06, so every command in that block failed. Replaced with the local `m2c` CLI flow.
- **Deployment Manager**, past end of support, cut to a dated note. **Infrastructure Manager added properly** -- Google's managed Terraform service and the named successor, which appeared nowhere in the repo despite objective 5.2 making IaC explicit. Covers deployments, revisions, previews, resource drift, the nominated service account, and the no-`backend`-block and no-`provisioners` constraints. Wired into the IaC comparison table (rebuilt with "who runs it" and "identity used" rows), the exam tips, the decision tree and the checklist.
- **Apigee tiers.** The old table invented an "Apigee Integrated" tier and miscategorised Apigee X as a tier rather than the platform generation. Replaced with three tables: pricing model, the real Standard / Enterprise / Enterprise Plus entitlements, and deployment option.

## Objective 6.1 restructured

`docs/06:13-22` presented hand-written SRE principles as *the* Well-Architected operational excellence principles. Objective 6.1 asks for Google's published set verbatim, so a question quoting Google's wording was not answerable from this file. Both docs now carry the published five, with the SRE material kept as explicitly labelled supporting context.

## Numbers corrected

Cloud Shell (40 min inactivity, 12 h session cap, 50 h/week, 120-day `$HOME` deletion -- the old text said 20 min and 120 min); Cloud Monitoring retention (24 months, and log-based metrics 6 weeks, not the stated 5 years and 24 months); Customer Care minimums ($100 Enhanced, $15,000 Premium); GKE maintenance exclusions (90 days for `no_upgrades`, not 180, plus the 48-hour-per-92-day rule); Spanner `nam14` replica placement; the full inter-region egress table.

Availability arithmetic is now standardised on a 30-day month. It previously carried two different figures for the same SLO across five locations.

## Coverage added to docs/06

**Metrics scopes** (multi-project observability, arguably the key architect-level Cloud Monitoring topic and entirely absent), **SLO composition across dependent services** (serial multiplies availabilities, redundant multiplies unavailabilities, with the independence caveat), and **DORA's current five metrics**.

## Link rot repaired

All 141 distinct `cloud.google.com` links across the three files were checked. **Eight returned 404** and were repaired, including `choose-api-management`, `storage-transfer-service/docs`, `capacity-planning-and-management`, two `architecture/framework/*` paths, and `run/docs/testing/load-testing`. This was not in the brief.

## Also

Datastream destinations (BigQuery, Cloud Storage, Iceberg -- not Cloud SQL), Policy Denied log exemptions, Web Security Scanner targets, the `enable-osconfig` metadata key, alpha-only quota update, and the naming sweep. `gcr.io/cloud-builders/*` and `gcr.io/google.com/cloudsdktool/cloud-sdk` were deliberately left alone as Google-published images unaffected by the shutdown.

## Verification

Zero em dashes added, zero TODO markers. Every replacement fact came from `cloud.google.com`; nothing was left unverified.