### PR TITLE
fix(pca): errata sweep for decision trees and command reference

### DIFF
--- a/.claude/state/research/2026-08-09-pca-content-audit.md
+++ b/.claude/state/research/2026-08-09-pca-content-audit.md
@@ -98,7 +98,7 @@ A learner who types these gets "unrecognized". Highest-confusion class of error.
 - [ ] `docs/06:1226` - Enhanced support minimum "$500/month" (actual $100); Premium "contact sales" (published minimum $15,000/month).
 - [ ] `docs/06:2034`, `06:2105` - GKE maintenance exclusion `no_upgrades` "cannot exceed 180 days". Actual 90 days, plus a 48-hours-per-92-day-window rule.
 - [ ] `docs/05:621`, `05:647`, `05:727` - Cloud Shell "resets after 120 min inactivity" / "20 min idle". Actual: session ends after 40 minutes idle, 12-hour session cap, `$HOME` deleted after 120 days.
-- [ ] `docs/09:118` - Spanner "~$650/mo min". Wrong by 10x. Minimum is 100 processing units; 1000 PU = 1 node.
+- [x] `docs/09:118` - Spanner "~$650/mo min". Wrong by 10x. Minimum is 100 processing units; 1000 PU = 1 node.
 - [ ] `docs/01:576` - Spanner "1 node ~ 10,000 reads/sec or 2,000 writes/sec". Current: 22,500 peak reads/sec, 3,500 peak writes/sec (22,500 with throughput-optimized writes).
 - [ ] `docs/02:873` - Bigtable "10K rows/sec reads and writes". Current SSD node: up to 17,000 reads/sec, 14,000 writes/sec.
 - [ ] `docs/07:624` - `nam14` replica list wrong. Actual: read-write in us-east4 (default leader) and northamerica-northeast1, witness in us-east1.
@@ -115,9 +115,9 @@ A learner who types these gets "unrecognized". Highest-confusion class of error.
 - [ ] `docs/02:740`, `02:751`, `01:237` - three different Transfer Appliance capacities, all retired. Current models are TA40 (40 TB) and TA300 (300 TB).
 - [ ] `docs/02:1089` - M2 listed as "12-416" vCPUs. M2 starts at 208. M1 and M4 missing entirely.
 - [ ] `docs/03:252` - SDP "150+ built-in detectors". Actual 200+.
-- [ ] `docs/09:311` - Interconnect 99.9% SLA needs two connections in different edge availability domains, not just one metro.
-- [ ] `docs/09:305`, `09:309`, `09:367` - Dedicated Interconnect "10-200 Gbps". Now 10, 100 and 400 Gbps link types.
-- [ ] `docs/09:322`, `09:329`, `09:369` and `02:22` - HA VPN "3 Gbps per tunnel". Documented limit is 250,000 packets/sec, which is 1-3 Gbps depending on packet size.
+- [x] `docs/09:311` - Interconnect 99.9% SLA needs two connections in different edge availability domains, not just one metro.
+- [x] `docs/09:305`, `09:309`, `09:367` - Dedicated Interconnect "10-200 Gbps". Now 10, 100 and 400 Gbps link types.
+- [ ] `docs/09:322`, `09:329`, `09:369` and `02:22` - HA VPN "3 Gbps per tunnel". Documented limit is 250,000 packets/sec, which is 1-3 Gbps depending on packet size. (`docs/09` occurrences fixed; `02:22` still open.)
 - [ ] `docs/07:858-862` - inter-region egress "$0.01/GB". Within North America it is $0.02/GB.
 - [x] `docs/07:711` and `02:596` conflict on storage class SLAs. `02:596` is correct (99.9% multi/dual-region, 99.0% regional for the cold classes). `07:711` flattens all three to 99.0% and is wrong.
 - [ ] `docs/01:727` - Dedicated Interconnect "99.9% (1 link)". A single link carries no SLA.
@@ -146,21 +146,21 @@ A learner who types these gets "unrecognized". Highest-confusion class of error.
 - [ ] `docs/05:165` - "Apigee Integrated" tier does not exist. Tiers are Standard, Enterprise, Enterprise Plus, plus pay-as-you-go.
 - [ ] `docs/05:372-397` - the entire Migrate to Containers section is dead. `migctl` and the processing-cluster flow were removed in May 2024.
 - [ ] `docs/05:2271` - decision tree offers "service account with key (or WIF)" for CI/CD. Keys should be a distractor, not a branch. Contradicts `05:2055`.
-- [ ] `docs/09:15`, `09:98` - "Autopilot has no DaemonSets" and "need DaemonSets or GPUs, use Standard". Both wrong, stated twice. Autopilot supports both.
-- [ ] `docs/09:148`, `09:200` - "Firestore cannot change mode after creation". An empty database can switch, and both modes can coexist in one project.
-- [ ] `docs/09:141` - "Firestore under 10 TB" as a branch condition. No such documented limit; invented threshold.
-- [ ] `docs/09:157` - "Bigtable has no SQL". GoogleSQL for Bigtable is GA.
-- [ ] `docs/09:113` - "Spanner 99.999% SLA" as the entry condition. Five nines is multi-region only; regional is 99.99%.
-- [ ] `docs/09:120`, `09:196` - AlloyDB "4x Cloud SQL performance". The claim is 4x standard PostgreSQL.
-- [ ] `docs/09:556` - conflates CSEK and EKM. The file's own tip at `09:602` gets it right.
-- [ ] `docs/09:540-542` - recommends network tags over service accounts for firewall targeting. Google recommends the opposite; secure tags now close the gap.
-- [ ] `docs/09:808` - "Cloud SQL cross-region DR requires manual promotion". Enterprise Plus supports advanced DR with replica failover and zero-data-loss switchover.
-- [ ] `docs/09:765` - turbo replication placed in "hot DR, RPO seconds to minutes". Its guarantee is 15 minutes, matching `09:281`/`09:809`.
-- [ ] `docs/10:765` - "network policy requires Calico, enabled by default on Standard". Not enabled by default; Dataplane V2 is the recommended plugin and the Autopilot default.
-- [ ] `docs/10:136-139` - the global external ALB snippet builds a classic ALB. Needs `--load-balancing-scheme=EXTERNAL_MANAGED` on backend service and forwarding rule. Contradicts `09:410-411`.
-- [ ] `docs/10:113-116` - HA VPN example uses `--peer-gcp-gateway` (VPC-to-VPC) while the text describes the on-prem case, which needs `--peer-external-gateway`.
-- [ ] `docs/10:57-61` - WIF OIDC provider created with no `--attribute-condition`. For the GitHub issuer this lets any repository mint tokens. Must be repository-scoped.
-- [ ] `docs/10:815` - `gsutil signurl` requires a downloaded SA key, contradicting `09:506` ("no service account keys, ever"). Use `gcloud storage sign-url --impersonate-service-account`.
+- [x] `docs/09:15`, `09:98` - "Autopilot has no DaemonSets" and "need DaemonSets or GPUs, use Standard". Both wrong, stated twice. Autopilot supports both.
+- [x] `docs/09:148`, `09:200` - "Firestore cannot change mode after creation". An empty database can switch, and both modes can coexist in one project.
+- [x] `docs/09:141` - "Firestore under 10 TB" as a branch condition. No such documented limit; invented threshold.
+- [x] `docs/09:157` - "Bigtable has no SQL". GoogleSQL for Bigtable is GA.
+- [x] `docs/09:113` - "Spanner 99.999% SLA" as the entry condition. Five nines is multi-region only; regional is 99.99%.
+- [x] `docs/09:120`, `09:196` - AlloyDB "4x Cloud SQL performance". The claim is 4x standard PostgreSQL.
+- [x] `docs/09:556` - conflates CSEK and EKM. The file's own tip at `09:602` gets it right.
+- [x] `docs/09:540-542` - recommends network tags over service accounts for firewall targeting. Google recommends the opposite; secure tags now close the gap.
+- [x] `docs/09:808` - "Cloud SQL cross-region DR requires manual promotion". Enterprise Plus supports advanced DR with replica failover and zero-data-loss switchover.
+- [x] `docs/09:765` - turbo replication placed in "hot DR, RPO seconds to minutes". Its guarantee is 15 minutes, matching `09:281`/`09:809`.
+- [x] `docs/10:765` - "network policy requires Calico, enabled by default on Standard". Not enabled by default; Dataplane V2 is the recommended plugin and the Autopilot default.
+- [x] `docs/10:136-139` - the global external ALB snippet builds a classic ALB. Needs `--load-balancing-scheme=EXTERNAL_MANAGED` on backend service and forwarding rule. Contradicts `09:410-411`.
+- [x] `docs/10:113-116` - HA VPN example uses `--peer-gcp-gateway` (VPC-to-VPC) while the text describes the on-prem case, which needs `--peer-external-gateway`.
+- [x] `docs/10:57-61` - WIF OIDC provider created with no `--attribute-condition`. For the GitHub issuer this lets any repository mint tokens. Must be repository-scoped.
+- [x] `docs/10:815` - `gsutil signurl` requires a downloaded SA key, contradicting `09:506` ("no service account keys, ever"). Use `gcloud storage sign-url --impersonate-service-account`.
 - [ ] `docs/01:1082` - "Migration Center (formerly Migrate for Compute Engine)". False lineage; M4CE became Migrate to VMs, Migration Center is a separate product. File contradicts itself at `01:1093`.
 - [ ] `docs/01:795` - "Vertex AI Conversation replaces Dialogflow CX for new projects". Dialogflow CX is the underlying engine, rebranded Conversational Agents. Never replaced.
 - [ ] `docs/01:949`, `01:676` - dual-region "sub-second failover" / "near-zero RPO". No such guarantee. Default is most objects within 15 minutes; turbo guarantees 15 min for 100%.
@@ -180,19 +180,19 @@ The Vertex AI rebrand is the big one and is a rewrite, not a find-and-replace.
 - [ ] **Anthos to GKE Enterprise**, **Anthos Service Mesh + Traffic Director to Cloud Service Mesh**: `docs/01:279`, `01:641`, `01:742`, `01:1043`, `02:425`, `02:1505`, `04:429`, `04:668`, `04:749`, `04:790`, `04:820`, `04:972`, `06:788`, `06:1586`, `06:1660`, `06:1674`, `07:102`, `07:469`, `07:1005`, `07:1388`, `05:115`.
 - [ ] **Container Registry shut down** (writes 2025-03-18, reads 2025-06-03) but `gcr.io` still used in examples: `docs/02:1363`, `02:1370`, `05:297`, `05:301`, `05:305`, `05:1671`, `06:867`, `06:892`, `06:976`, `06:1000`, `07:178`. Also listed as a VPC-SC protectable service at `03:369`.
 - [ ] **Cloud Functions to Cloud Run functions**: `docs/01:1018`, `05:169`, `05:216`, `05:238`, `06:622`, `06:641`, `07:562`, `07:977`, `07:803`, `07:1109`, `07:1231`, `questions/section-5-managing-implementations.md:229`, `:531`.
-- [ ] **Dataproc to Managed Service for Apache Spark**: `docs/09:62-66`, `09:93`, `09:100`, `09:891`, `09:1002`.
-- [ ] **Migrate for Compute Engine to Migrate to Virtual Machines**: `docs/09:835`, `09:889`, `09:903`, `09:1033`, `05:399`, `05:555`. M4CE v4.11 end of support 2024-04-30.
+- [x] **Dataproc to Managed Service for Apache Spark**: `docs/09:62-66`, `09:93`, `09:100`, `09:891`, `09:1002`.
+- [ ] **Migrate for Compute Engine to Migrate to Virtual Machines**: `docs/09:835`, `09:889`, `09:903`, `09:1033`, `05:399`, `05:555`. M4CE v4.11 end of support 2024-04-30. (`docs/09` occurrences fixed, including a fifth in the migration execution step; `docs/05` still open.)
 - [ ] **BeyondCorp Enterprise to Chrome Enterprise Premium**: `questions/section-3-security-compliance.md:749`.
 - [ ] **Cloud Operations Suite to Google Cloud Observability**: `docs/01:414`, `07:222`, `07:1476`.
 - [ ] **Cloud Source Repositories** closed to new customers 2024-06-17, presented as live: `docs/01:180`, `04:28`, `04:580`. Successor is Secure Source Manager.
 - [ ] **Deployment Manager** past end of support 2026-03-31, new users blocked from 2026-06-30: `docs/05:1809-1841`, `09:937-941`, `09:967`, `09:974`, `10:592`, `10:600`, `04:881`.
-- [ ] **Memorystore for Memcached deprecated** (no new instances after 2027-02-01, shutdown 2029-01-31): `docs/09:174`, `09:191`. Memorystore for Valkey missing entirely from the in-memory branch.
+- [x] **Memorystore for Memcached deprecated** (no new instances after 2027-02-01, shutdown 2029-01-31): `docs/09:174`, `09:191`. Memorystore for Valkey missing entirely from the in-memory branch.
 - [ ] **PaLM 2 and Codey retired** April 2025: `docs/02:2156`, `09:634`.
 - [ ] **Model Armor is under Security Command Center**, not Vertex AI: `questions/section-3-security-compliance.md:654`, `docs/03:650-654` (also wrong doc URL).
 - [ ] **Cloud Armor Managed Protection Plus to Cloud Armor Enterprise**: `docs/02:214`.
 - [ ] **Private Catalog to Service Catalog** (renamed March 2022): `docs/04:879`, `04:936-937`.
 - [ ] **Terraform Cloud to HCP Terraform**: `docs/05:1262`.
-- [ ] **gsutil to gcloud storage.** gsutil leaves the CLI bundle March 2027. `docs/10:806-825` gives gsutil its own section while `gcloud storage` is absent. Invert the emphasis but keep gsutil, since the exam guide still names it.
+- [x] **gsutil to gcloud storage.** gsutil leaves the CLI bundle March 2027. `docs/10:806-825` gives gsutil its own section while `gcloud storage` is absent. Invert the emphasis but keep gsutil, since the exam guide still names it.
 - [ ] Dated version pins that will rot: TPU v3 (`questions/section-1-designing-planning.md:472`), GKE 1.28/1.29 (`section-6:587`), pd-ssd with no Hyperdisk (`section-2:492`), provider `~> 5.0` (`docs/10:285-294`, `05:1122-1129`) against a current 7.x, `POSTGRES_15` (`10:505`), CFT module pins (`10:412`, `10:427`).
 - [ ] `docs/06:1589` - Istio `networking.istio.io/v1alpha3`. Current is `v1` since Istio 1.22.
 - [ ] `docs/02:5` claims "Last updated: February 2026", now stale and predating the rebrand. `docs/01` has no last-updated marker.
@@ -220,19 +220,19 @@ The Vertex AI rebrand is the big one and is a rewrite, not a find-and-replace.
 ## P3 - coverage gaps against the v6.1 exam guide
 
 - [ ] **Google Cloud VMware Engine** - named verbatim in objective 2.3, zero mentions anywhere. Belongs in `docs/02` under 2.3.
-- [ ] **Infrastructure Manager** - Google's managed Terraform and the named Deployment Manager replacement. Absent from `docs/05` and `docs/09` section 10. Biggest single gap given v6.1 made IaC explicit.
+- [ ] **Infrastructure Manager** - Google's managed Terraform and the named Deployment Manager replacement. Absent from `docs/05` and `docs/09` section 10. Biggest single gap given v6.1 made IaC explicit. (Added to the `docs/09` IaC tree, quick reference and exam tips, and to the `docs/10` IaC comparison table; `docs/05` still open.)
 - [ ] **Confidential Computing** - Confidential VMs, Confidential GKE Nodes, Confidential Space. Absent from `docs/03`.
 - [ ] **Workforce Identity Federation** - absent; only Workload Identity Federation is covered (`docs/03:529-560`). The workforce/workload distinction is a classic trap.
 - [ ] **Privileged Access Manager** - the canonical answer for just-in-time elevation and break-glass. Missing from separation of duties (`docs/03:269-303`).
 - [ ] **Cloud NGFW Enterprise** - objective 2.1 names intrusion protection; `docs/02:247-266` covers only Cloud IDS, which is detection-only.
-- [ ] **Network Connectivity Center** - two passing rows (`docs/02:188`, `02:344`), absent from the `docs/09` connectivity tree. Objective 2.1 covers exactly this.
+- [ ] **Network Connectivity Center** - two passing rows (`docs/02:188`, `02:344`). Now covered in the new `docs/09` section 12 network topology tree; `docs/02` still open. Objective 2.1 covers exactly this.
 - [ ] **Metrics scopes** - multi-project observability, arguably the architect-level Cloud Monitoring topic. Absent from `docs/06`.
 - [ ] **SLO composition across dependent services** - the multiplicative rule is a classic PCA calculation, absent.
 - [ ] **DORA metrics** - absent from all files despite Google owning the research and citing it throughout WAF.
 - [ ] **Cloud Customer Care tiers** - `docs/04:1327-1377` "customer success" is effectively a second SLO section. Exam items framed as customer success often resolve to picking a support tier, and there is no basis for that here.
 - [ ] **Dynamic Workload Scheduler** - objective 2.4's "optimizing for different consumption models" is exactly this. Absent.
 - [ ] **Gemini Enterprise** (objective 2.5: AI Agents and NotebookLM) - NotebookLM gets one row; AI Agents absent.
-- [ ] Missing decision trees in `docs/09`, ranked by expected yield: resource hierarchy / landing zone, network topology selection, data pipeline and ingestion, multi-tenancy isolation, identity and federation, CI/CD topology, AI/ML serving, caching strategy, observability and logging architecture, cost optimization, compliance and data residency, encryption key strategy.
+- [ ] Missing decision trees in `docs/09`, ranked by expected yield. Resource hierarchy / landing zone (now section 11) and network topology selection (now section 12) are done. Still missing: data pipeline and ingestion, multi-tenancy isolation, identity and federation, CI/CD topology, AI/ML serving, caching strategy, observability and logging architecture, cost optimization, compliance and data residency, encryption key strategy.
 - [ ] Thin relative to weight: securing AI (`docs/03:648-681`, 33 lines for a named objective), envisioning future improvements (`docs/01:1177-1237`, all of 1.5), success measurements (`docs/01:331-354`), Cloud Code (`docs/05:661-682`).
 - [ ] `docs/06:13-22` and `07:53-65` - the operational excellence "key principles" are hand-written SRE principles, not Google's published pillar principles. Objective 6.1 reads verbatim "the principles and recommendations of the operational excellence pillar", so a question quoting Google's wording would not be recognisable.
 

--- a/gcp/pca/docs/09-decision-trees.md
+++ b/gcp/pca/docs/09-decision-trees.md
@@ -12,7 +12,8 @@ What is the workload?
 │
 ├── Containers / microservices?
 │   │
-│   ├── Need full K8s control (node pools, GPUs, DaemonSets, custom schedulers)?
+│   ├── Need node-level access (privileged containers, unsafe sysctls,
+│   │   custom node image or kernel tuning, SSH to nodes)?
 │   │   └── ✅ GKE Standard
 │   │       ├── Stateful workloads (StatefulSets, PVCs)? → GKE Standard
 │   │       ├── Multi-cluster mesh / Anthos? → GKE Enterprise (fleet)
@@ -20,7 +21,11 @@ What is the workload?
 │   │
 │   ├── K8s but no node ops (pay-per-pod, auto-secured)?
 │   │   └── ✅ GKE Autopilot
-│   │       ⚠️  No SSH to nodes, no privileged pods, no DaemonSets
+│   │       ⚠️  DaemonSets, GPUs and TPUs all work on Autopilot. "We need
+│   │           DaemonSets" or "we need GPUs" is NOT a reason to pick Standard
+│   │       ⚠️  What Autopilot actually blocks: SSH to nodes, privileged
+│   │           containers (outside the partner allowlist), host namespaces,
+│   │           unsafe sysctls, and any change to the node image
 │   │       ⚠️  Best for teams that want K8s API without infra burden
 │   │
 │   ├── Single container, request-driven, no cluster overhead?
@@ -60,10 +65,13 @@ What is the workload?
 │   │       ⚠️  Provisions VMs automatically, supports GPU, Spot
 │   │
 │   ├── Apache Spark / Hadoop / Hive / Presto ecosystem?
-│   │   └── ✅ Dataproc
-│   │       ├── Short-lived cluster per job? → Dataproc on Compute Engine
-│   │       ├── Shared multi-tenant? → Dataproc on GKE
-│   │       └── Serverless, no cluster management? → Dataproc Serverless
+│   │   └── ✅ Managed Service for Apache Spark (formerly Dataproc)
+│   │       ├── Short-lived cluster per job? → cluster deployment
+│   │       ├── Shared multi-tenant on K8s? → Spark on GKE
+│   │       └── No cluster to manage at all? → serverless deployment
+│   │       ⚠️  The exam guide, the API and most docs URLs still say "Dataproc".
+│   │           Same product: cluster and serverless deployments were unified
+│   │           under the Managed Service for Apache Spark name
 │   │
 │   └── Apache Beam (unified batch + stream)?
 │       └── ✅ Dataflow
@@ -90,14 +98,14 @@ What is the workload?
 | "SAP HANA, Oracle DB, BYOL" | Sole-tenant nodes | Dedicated physical servers, license compliance |
 | "HPC, MPI, tightly coupled" | CE + compact placement | Low-latency node-to-node networking |
 | "1000 rendering jobs, tolerate preemption" | Cloud Batch + Spot | Automatic VM provisioning, retry on preempt |
-| "Migrate Spark pipelines from on-prem" | Dataproc | Drop-in Hadoop/Spark, ephemeral clusters |
+| "Migrate Spark pipelines from on-prem" | Managed Service for Apache Spark (Dataproc) | Drop-in Hadoop/Spark, ephemeral clusters |
 | "Real-time stream + batch in one pipeline" | Dataflow | Apache Beam, auto-scaling, exactly-once |
 | "Legacy App Engine app, minimal changes" | App Engine Flexible | Docker-based, compatible with legacy config |
 
 **Exam Tips:**
-- GKE Autopilot vs Standard is a frequent question -- Autopilot = no node management, no SSH, no DaemonSets, Pod Security enforced.
+- GKE Autopilot vs Standard is a frequent question, and the distinguishing axis is **node-level access**, not workload type. Autopilot = no SSH, no privileged containers, no host namespaces, no unsafe sysctls, no node image control. DaemonSets, GPUs and TPUs are all supported on Autopilot, so an option that justifies Standard with "they need DaemonSets" or "they need GPUs" is a distractor. ([Autopilot security measures](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-security), [Autopilot vs Standard comparison](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison))
 - Cloud Run functions (2nd gen) is built on Cloud Run. If the question says "serverless function," either answer may apply -- look for "no infrastructure" = Cloud Run functions, "container" = Cloud Run.
-- Dataproc is the answer whenever you see Spark, Hadoop, Hive, or Presto. Dataflow is for Beam.
+- [Managed Service for Apache Spark](https://cloud.google.com/products/managed-service-for-apache-spark) (the product formerly named Dataproc) is the answer whenever you see Spark, Hadoop, Hive, or Presto. Dataflow is for Beam. Exam options will most likely still be worded "Dataproc".
 - Cloud Batch is the answer for "schedule thousands of containerized jobs with retries" (not Dataflow, not Dataproc).
 - App Engine: one per project, cannot delete. If the question involves multiple apps in one project, that is a trap.
 
@@ -110,19 +118,30 @@ What is the data model and scale?
 │
 ├── Relational (SQL, ACID, joins)?
 │   │
-│   ├── Global scale, 99.999% SLA, unlimited horizontal scaling?
+│   ├── Horizontal write scaling with strong global consistency?
 │   │   └── ✅ Cloud Spanner
-│   │       ├── Multi-region for HA? → Multi-region Spanner config
+│   │       ├── Single region? → regional config, 99.99% SLA
+│   │       ├── Five nines needed? → multi-region or dual-region config,
+│   │       │   99.999% SLA, and that tier requires the Enterprise Plus edition
 │   │       ├── Need PostgreSQL interface? → Spanner PostgreSQL dialect
 │   │       └── Financial / inventory (strong global consistency)? → Spanner
-│   │       ⚠️  Starts at ~$0.90/node/hr (~$650/mo min). Cost-justified at scale.
+│   │       ⚠️  Editions: Standard, Enterprise, Enterprise Plus. Graph, full-text
+│   │           and vector search start at Enterprise; 99.999% and geo-partitioning
+│   │           need Enterprise Plus
+│   │       ⚠️  Compute is bought in processing units. Minimum is 100 PU and
+│   │           1000 PU = 1 node, so the entry point is a tenth of a node, not a
+│   │           whole one. "Spanner forces you to buy a full node" is a trap
 │   │
-│   ├── PostgreSQL-compatible, need 4x Cloud SQL performance?
+│   ├── PostgreSQL-compatible, need more headroom than Cloud SQL gives?
 │   │   └── ✅ AlloyDB
 │   │       ├── HTAP (transactions + analytics on same data)? → AlloyDB
+│   │       │   columnar engine
 │   │       ├── AI/ML embeddings, vector search? → AlloyDB AI
 │   │       └── Cross-region read replicas? → AlloyDB
 │   │       ⚠️  PostgreSQL only. No MySQL, no SQL Server.
+│   │       ⚠️  Google's published speed multiplier is against standard open-source
+│   │           PostgreSQL, not against Cloud SQL. An option that reads "4x faster
+│   │           than Cloud SQL" is restating the benchmark wrongly
 │   │
 │   ├── Standard managed RDBMS (MySQL, PostgreSQL, SQL Server)?
 │   │   └── ✅ Cloud SQL
@@ -138,14 +157,18 @@ What is the data model and scale?
 │
 ├── NoSQL -- Document / key-value?
 │   │
-│   ├── Mobile/web, real-time sync, offline support, < 10 TB?
+│   ├── Mobile/web, real-time sync, offline support?
 │   │   └── ✅ Firestore (Native mode)
 │   │       ├── Strong consistency, real-time listeners? → Native mode
 │   │       └── Need Datastore API backward compatibility? → Datastore mode
 │   │
 │   └── Large-scale server-side only, no real-time sync needed?
 │       └── ✅ Firestore (Datastore mode)
-│           ⚠️  Cannot switch modes after creation
+│           ⚠️  Mode is NOT welded on at creation: an EMPTY database can be
+│               switched between Native and Datastore mode. Only a database that
+│               already holds documents or entities is locked
+│           ⚠️  One project can hold many databases, and they can be a mix of both
+│               modes. "You must create a new project to change mode" is stale
 │
 ├── NoSQL -- Wide-column (time-series, IoT, high throughput)?
 │   │
@@ -154,8 +177,12 @@ What is the data model and scale?
 │       ├── Time-series, IoT sensor data, financial ticks? → Bigtable
 │       ├── Serving layer for ML feature store? → Bigtable
 │       └── HBase migration? → Bigtable (HBase-compatible API)
-│       ⚠️  No multi-row transactions. No SQL (use Bigtable client or cbt).
-│       ⚠️  Min 1 node (~$0.65/hr). Not cost-effective for small datasets.
+│       ⚠️  No multi-row transactions.
+│       ⚠️  GoogleSQL for Bigtable exists -- "Bigtable has no SQL" is out of date.
+│           It is SELECT-only: no INSERT/UPDATE/DELETE, no DDL, and no JOIN,
+│           UNION, CTEs or subqueries. So Bigtable is still the wrong answer for
+│           "we need joins", but right for "query it with familiar SQL syntax"
+│       ⚠️  Not cost-effective for small datasets -- you pay for provisioned nodes.
 │
 ├── Analytics / data warehouse?
 │   │
@@ -171,9 +198,16 @@ What is the data model and scale?
 └── In-memory cache / session store?
     │
     └── ✅ Memorystore
-        ├── Key-value cache, pub/sub, Lua scripting? → Memorystore for Redis
-        ├── Simple object caching, multi-threaded? → Memorystore for Memcached
-        └── Redis Cluster mode (> 300 GB, sharding)? → Memorystore for Redis Cluster
+        ├── New build, open-source engine, cluster mode on or off?
+        │   → Memorystore for Valkey
+        │     (shards of 1 primary + up to 5 replicas, spread across zones)
+        ├── Existing Redis workload, key-value cache, pub/sub, Lua scripting?
+        │   → Memorystore for Redis
+        ├── Sharded Redis, horizontal scaling? → Memorystore for Redis Cluster
+        └── Memcached protocol specifically? → Memorystore for Memcached
+            ⚠️  DEPRECATED (announced 2026-01-20). No new instances in projects
+                that do not already have one after 2027-02-01; shutdown
+                2029-01-31. Google's stated migration target is Valkey
 ```
 
 ### Database Quick Reference
@@ -189,15 +223,19 @@ What is the data model and scale?
 | "Petabyte analytics, ad hoc SQL" | BigQuery | Serverless warehouse, pay-per-query option |
 | "ML training on warehouse data" | BigQuery ML | Train models with SQL, no data movement |
 | "Session cache, sub-ms reads" | Memorystore (Redis) | In-memory, managed, HA available |
+| "New in-memory cache, no Redis licence baggage" | Memorystore for Valkey | Open-source engine, cluster mode optional |
+| "Existing Memcached workload to modernise" | Memorystore for Valkey | Memcached is deprecated; Valkey is the stated target |
 | "Cross-cloud query (S3 data)" | BigQuery Omni | Run BQ on AWS/Azure storage in-place |
 
 **Exam Tips:**
 - Spanner vs Cloud SQL: if the question mentions "global," "horizontal scaling for writes," or "five 9s," it is Spanner. If "single region" and "MySQL/PostgreSQL," it is Cloud SQL.
-- AlloyDB appears when the question says "PostgreSQL" + "analytics on operational data" or "4x performance."
-- Bigtable is never the answer for "complex queries" or "joins." It is for single-key or range-scan workloads at massive scale.
+- Spanner's five-nines number is **configuration-dependent**, not a property of the product. Regional Spanner is 99.99%. Only multi-region and dual-region configurations reach 99.999%, and that SLA tier belongs to the Enterprise Plus edition. An option that offers "regional Spanner for a 99.999% requirement" is wrong. ([Spanner SLA](https://cloud.google.com/spanner/sla), [Spanner editions](https://cloud.google.com/spanner/docs/editions-overview))
+- Spanner sizing is in processing units: 100 PU minimum, 1000 PU = 1 node. Small instances are genuinely small. ([Compute capacity](https://cloud.google.com/spanner/docs/compute-capacity))
+- AlloyDB appears when the question says "PostgreSQL" + "analytics on operational data." Its performance comparison is published against standard PostgreSQL, not against Cloud SQL. ([AlloyDB](https://cloud.google.com/alloydb/docs/overview))
+- Bigtable is never the answer for "joins." [GoogleSQL for Bigtable](https://cloud.google.com/bigtable/docs/googlesql-overview) added SQL SELECT queries, but joins, subqueries and DML are still unsupported, so "no SQL at all" and "full SQL" are both wrong descriptions.
 - BigQuery is not OLTP. If the scenario requires low-latency transactional reads/writes, BigQuery is the wrong answer.
 - Bare Metal Solution: if you see "Oracle RAC" or "cannot modify application," this is likely the answer.
-- Firestore: cannot change mode (Native vs Datastore) after database creation.
+- [Firestore mode](https://cloud.google.com/firestore/docs/firestore-or-datastore): switchable while the database is empty, and a single project can hold both Native-mode and Datastore-mode databases. Treat "mode is permanent, create a new project" as the distractor.
 
 ---
 
@@ -302,14 +340,18 @@ What type of storage?
 ```
 Connect on-premises / other cloud to GCP?
 │
-├── Need highest bandwidth (10-200 Gbps), dedicated physical line?
+├── Need highest bandwidth, dedicated physical line?
 │   │
 │   ├── Can colocate at a Google edge PoP?
 │   │   └── ✅ Dedicated Interconnect
-│   │       ├── 10 Gbps or 100 Gbps circuits
-│   │       ├── 99.99% SLA requires 4 connections across 2 metro areas
-│   │       ├── 99.9% SLA requires 2 connections in 1 metro area
+│   │       ├── Link types: 10, 100 or 400 Gbps, up to 8 circuits per Interconnect
+│   │       ├── 99.99% SLA requires 4 connections: 2 in one metro and 2 in a
+│   │       │   second metro, and the pair inside each metro must sit in
+│   │       │   different edge availability domains
+│   │       ├── 99.9% SLA requires 2 connections in one metro, and they too must
+│   │       │   be in different edge availability domains
 │   │       └── Not encrypted by default (add MACsec or VPN overlay)
+│   │       ⚠️  Link type cannot be changed later -- size it at order time
 │   │       ⚠️  8-12 week lead time for provisioning
 │   │
 │   └── Cannot reach Google PoP directly?
@@ -319,14 +361,17 @@ Connect on-premises / other cloud to GCP?
 │           └── 99.99% SLA requires redundant connections
 │           ⚠️  Lower cost than Dedicated, but shared infrastructure
 │
-├── Need encrypted tunnel, moderate bandwidth (up to 3 Gbps/tunnel)?
+├── Need encrypted tunnel, moderate bandwidth?
 │   │
 │   └── ✅ HA VPN
 │       ├── 99.99% SLA (requires 2 tunnels + BGP)
 │       ├── IPsec encrypted by default
 │       ├── Quick to provision (hours, not weeks)
 │       ├── Can run over internet or over Interconnect (for encryption)
-│       └── Max 3 Gbps per tunnel (aggregate with multiple tunnels)
+│       └── Throttled at 250,000 packets/sec per tunnel, counting ingress and
+│           egress together. That is roughly 1-3 Gbps depending on average
+│           packet size, so a flat "3 Gbps per tunnel" figure is a simplification
+│           that breaks on small-packet traffic. Aggregate tunnels to go higher
 │       ⚠️  Classic VPN is deprecated for new deployments
 │
 ├── Connect to another cloud provider (AWS, Azure, Oracle)?
@@ -364,9 +409,9 @@ Connect on-premises / other cloud to GCP?
 
 | Scenario | Service | Architect Rationale |
 |----------|---------|---------------------|
-| "100 Gbps, lowest latency, can colocate" | Dedicated Interconnect | Physical cross-connect at Google PoP |
+| "100 or 400 Gbps, lowest latency, can colocate" | Dedicated Interconnect | Physical cross-connect at Google PoP |
 | "Need 1 Gbps, no Google PoP nearby" | Partner Interconnect | Provider extends reach |
-| "Encrypted tunnel, fast setup, < 10 Gbps" | HA VPN | IPsec, 99.99% SLA, quick provisioning |
+| "Encrypted tunnel, fast setup" | HA VPN | IPsec, 99.99% SLA, ~250k packets/sec per tunnel |
 | "Encrypt traffic over Interconnect" | HA VPN over Interconnect | VPN tunnels ride the Interconnect link |
 | "Connect GCP to AWS VPC directly" | Cross-Cloud Interconnect | Google-managed, dedicated cross-cloud |
 | "Multi-cloud, need encryption" | Cross-Cloud Interconnect + HA VPN overlay | CCI for bandwidth, VPN for encryption |
@@ -378,7 +423,8 @@ Connect on-premises / other cloud to GCP?
 **Exam Tips:**
 - Dedicated Interconnect is NOT encrypted by default. If the question asks for encryption + high bandwidth, the answer is HA VPN over Interconnect (or MACsec).
 - Cross-Cloud Interconnect is the PCA-level answer for "connect GCP to AWS/Azure with dedicated bandwidth." Do not confuse with Partner Interconnect (that is for on-prem).
-- 99.99% SLA for Dedicated Interconnect requires connections in 2 different metro areas (not just 2 connections in 1 metro).
+- Interconnect SLA tiers turn on **edge availability domains**, not just connection count. 99.9% needs 2 connections in one metro but in different edge availability domains; 99.99% needs 4 connections, 2 per metro across 2 metros, again split across domains within each metro. "Two connections in one metro" with no mention of domains does not earn 99.9%. ([Dedicated Interconnect overview](https://cloud.google.com/network-connectivity/docs/interconnect/concepts/dedicated-overview))
+- Cloud VPN's published limit is 250,000 packets/sec per tunnel, not a bandwidth number. If a question gives you a packet rate rather than a bit rate, that is the figure it is testing. ([Cloud VPN quotas](https://cloud.google.com/network-connectivity/docs/vpn/quotas))
 - Direct Peering is rarely the right answer on the PCA exam. It is for public Google service access, not private VPC connectivity.
 - Private Service Connect (PSC) is the modern answer for "access Google services with an internal IP." It replaces Private Google Access in many scenarios.
 
@@ -537,9 +583,20 @@ What security control is needed?
 │   │       └── No VPN needed for remote access
 │   │
 │   └── Firewall rules?
-│       ├── VPC Firewall Rules → basic allow/deny by IP, protocol, port
-│       ├── Firewall Policies → hierarchical (org → folder → project)
-│       └── Network tags vs service accounts → tags for firewall targeting
+│       ├── VPC firewall rules → basic allow/deny by IP, protocol, port
+│       ├── Firewall policies → hierarchical (org → folder → project), plus
+│       │   global and regional network firewall policies
+│       └── How do I target the rule at the right VMs?
+│           ├── Service accounts (target/source) → Google's recommendation when
+│           │   you need strict control. Attaching one needs permission on the
+│           │   service account, so the target set cannot be widened casually
+│           ├── Network tags → free-form strings. Anyone with instance edit
+│           │   permission can add a tag and pull a VM into a rule's scope,
+│           │   which is exactly why they are the weaker choice
+│           └── Secure tags (Resource Manager tags) → IAM-governed key/value
+│               pairs, usable as sources and targets in network firewall
+│               policies. These close the governance gap that made plain
+│               network tags a poor control
 │
 ├── Encryption & key management?
 │   │
@@ -552,10 +609,21 @@ What security control is needed?
 │   │       ├── Automatic rotation schedules
 │   │       └── IAM controls who can use/manage keys
 │   │
-│   ├── Customer holds key outside Google entirely?
-│   │   └── ✅ Cloud EKM (External Key Manager) -- CSEK or EKM
-│   │       ├── Key never leaves customer's external KMS
-│   │       └── Key Access Justifications (see why Google needs key)
+│   ├── Key material must stay in the customer's own key manager?
+│   │   └── ✅ Cloud EKM (External Key Manager)
+│   │       ├── Key never leaves the external KMS; Cloud KMS holds a reference
+│   │       │   and calls out to it for each cryptographic operation
+│   │       └── Pairs with Key Access Justifications (see, and optionally deny,
+│   │           the stated reason for each access)
+│   │
+│   ├── Customer supplies a raw key on every single API call?
+│   │   └── ✅ CSEK (customer-supplied encryption keys)
+│   │       ⚠️  NOT the same thing as EKM. With CSEK you pass a base64 AES-256
+│   │           key with each request; Google keeps only a hash for validation
+│   │           and never stores the key, so losing it means losing the data
+│   │       ⚠️  Narrow surface (Cloud Storage objects, Compute Engine disks) and
+│   │           no bucket-level default. CMEK is the architect answer in almost
+│   │           every "customer controls the key" scenario
 │   │
 │   └── Confidential computing (encrypt data in use)?
 │       └── ✅ Confidential VMs / Confidential GKE Nodes
@@ -603,6 +671,7 @@ What security control is needed?
 - Binary Authorization: if the question mentions "only allow vetted images," "container signing," or "attestation," this is the answer.
 - IAM Deny policies: these are evaluated before allow policies. Use them for hard guardrails that cannot be overridden by lower-level allows.
 - IAP replaces VPN for BeyondCorp / zero-trust access. If the question says "no VPN," think IAP.
+- Firewall targeting: Google recommends **target and source service accounts** over network tags where strict control matters, because a network tag can be attached by anyone with instance edit permission while attaching a service account requires permission on that service account. [Secure tags](https://cloud.google.com/firewall/docs/tags-firewalls-overview) are the IAM-governed middle ground and work as sources and targets in network firewall policies. An answer that recommends network tags "for tighter security" is inverted. ([VPC firewall rules](https://cloud.google.com/vpc/docs/firewalls))
 
 ---
 
@@ -760,9 +829,13 @@ What are the RPO / RTO requirements?
 │       │   RTO: minutes (DNS switch, health check failover)
 │       │   Cost: $$$ (full duplicate infrastructure)
 │       │
-│       ├── Cloud SQL: HA config (auto-failover within region)
+│       ├── Cloud SQL: HA config in-region, plus Enterprise Plus advanced DR
+│       │   (designated cross-region DR replica, failover, and a zero-data-loss
+│       │   switchover for failback and DR drills)
 │       ├── Spanner: multi-region (automatic)
-│       ├── GCS: turbo replication (< 15 min RPO)
+│       ├── GCS: dual-region + turbo replication. Note the guarantee is 15
+│       │   MINUTES, not seconds -- turbo tightens the tail, it does not make
+│       │   object replication synchronous
 │       └── GCLB: health checks auto-route away from failed region
 │
 └── RPO: zero, RTO: zero, highest cost?
@@ -805,7 +878,7 @@ What are the RPO / RTO requirements?
 **Exam Tips:**
 - PCA exam loves RPO/RTO questions. Map requirements to the strategy: zero RPO = active-active or synchronous replication, hours RPO = async + backups.
 - Spanner multi-region gives you active-active out of the box. If the question mentions "global consistency + zero RPO," Spanner is the database answer.
-- Cloud SQL HA is intra-region only (automatic failover to standby zone). Cross-region DR requires manually promoting a cross-region read replica.
+- Cloud SQL HA is intra-region (automatic failover to a standby in another zone). For cross-region DR the answer now depends on edition: **Enterprise** means promoting a cross-region read replica, which is manual and one-way. **Enterprise Plus** adds [advanced disaster recovery](https://cloud.google.com/sql/docs/postgres/intro-to-cloud-sql-disaster-recovery) -- you fail over to a designated DR replica, the old primary automatically rejoins as a replica instead of being orphaned, and a switchover operation gives zero-data-loss failback. That switchover is also what makes non-destructive DR drills possible.
 - Turbo replication on dual-region GCS buckets gives < 15 min RPO. Without turbo, replication is "best effort."
 - The PCA exam often asks you to balance cost vs RTO/RPO. Cold is cheapest but slowest. Active-active is fastest but most expensive. A good architect picks the cheapest option that meets the SLA.
 
@@ -832,7 +905,9 @@ What should you do with this application?
 │   │
 │   ├── Lift-and-shift (VM → VM, no code changes)?
 │   │   └── ✅ Rehost
-│   │       ├── Migrate for Compute Engine (M4CE) → automated VM migration
+│   │       ├── Migrate to Virtual Machines → automated VM migration from
+│   │       │   VMware, AWS, Azure or VMware Engine (this is the product
+│   │       │   formerly called Migrate for Compute Engine / M4CE)
 │   │       ├── Bare Metal Solution → Oracle, SAP (no changes)
 │   │       ├── Fastest migration path
 │   │       └── Does NOT leverage cloud-native benefits
@@ -841,7 +916,7 @@ What should you do with this application?
 │   └── Move + optimize (change platform, not code)?
 │       └── ✅ Replatform
 │           ├── MySQL on VM → Cloud SQL (managed, same engine)
-│           ├── Hadoop on-prem → Dataproc (managed Hadoop)
+│           ├── Hadoop on-prem → Managed Service for Apache Spark
 │           ├── Redis on VM → Memorystore (managed Redis)
 │           ├── Containers on VM → GKE or Cloud Run
 │           └── Moderate effort, good cloud-native gains
@@ -878,7 +953,7 @@ Step 3: Execute
 ├── Foundation: landing zone (org, folders, VPC, IAM, logging)
 ├── Networking: Interconnect / VPN to on-prem
 ├── Data: Database Migration Service, Storage Transfer Service
-├── Compute: Migrate for Compute Engine, containerization
+├── Compute: Migrate to Virtual Machines, containerization
 └── Validate: parallel run, cut-over, decommission source
 ```
 
@@ -886,9 +961,9 @@ Step 3: Execute
 
 | Scenario | Strategy | Key Services |
 |----------|----------|-------------|
-| "Move 200 VMs fast, no code changes" | Rehost | Migrate for Compute Engine (M4CE) |
+| "Move 200 VMs fast, no code changes" | Rehost | Migrate to Virtual Machines |
 | "MySQL on VM → managed MySQL" | Replatform | Database Migration Service → Cloud SQL |
-| "On-prem Hadoop → cloud" | Replatform | Dataproc (managed Spark/Hadoop) |
+| "On-prem Hadoop → cloud" | Replatform | Managed Service for Apache Spark (Dataproc) |
 | "Monolith → microservices on K8s" | Refactor | GKE, Cloud Run, Pub/Sub |
 | "Replace Exchange with Gmail" | Repurchase | Google Workspace |
 | "Oracle RAC, cannot change anything" | Rehost | Bare Metal Solution |
@@ -900,7 +975,7 @@ Step 3: Execute
 **Exam Tips:**
 - The PCA exam tests the 6 R's extensively. The key is matching the scenario constraints (time, budget, skill, business criticality) to the right strategy.
 - "Minimal changes" + "fastest migration" = Rehost. "Some changes to platform" = Replatform. "Redesign for cloud" = Refactor.
-- Migrate for Compute Engine (M4CE) is the go-to tool for VM rehosting. Database Migration Service (DMS) is for database replatforming.
+- [Migrate to Virtual Machines](https://cloud.google.com/migrate/virtual-machines/docs) is the go-to tool for VM rehosting. It is the current name for what older material calls Migrate for Compute Engine or M4CE, and it is a different product from Migration Center (which does assessment and portfolio discovery, not the move). Database Migration Service (DMS) is for database replatforming.
 - Rehost is often a stepping stone. The architect answer may be "rehost now, refactor later" (two-phase migration).
 - Landing zone first: the exam expects you to set up org hierarchy, IAM, networking, and logging BEFORE migrating workloads.
 - Wave planning: migrate tightly coupled apps together. Do not break dependencies across migration waves.
@@ -932,13 +1007,29 @@ How to manage GCP infrastructure as code?
 │       └── Reconciliation loop (controller continuously enforces state)
 │       ⚠️  Only GCP resources. Not multi-cloud.
 │
+├── Want Terraform, but without running the state and the runners yourself?
+│   │
+│   └── ✅ Infrastructure Manager (Infra Manager)
+│       ├── Runs standard Terraform HCL -- no new language, no rewrite
+│       ├── Google stores state, revisions and logs per deployment
+│       ├── Executes terraform in ephemeral Cloud Build jobs under a service
+│       │   account you nominate
+│       ├── Config source: Cloud Storage, a Git repo, or a local directory
+│       └── Preview a deployment before applying it
+│       ⚠️  This is the named successor to Deployment Manager, and it is the
+│           answer to "we want IaC on Google Cloud but do not want to own a
+│           state bucket and a CI runner"
+│
 ├── Google-native, YAML-based, no external tooling?
 │   │
-│   └── ⚠️  Deployment Manager (DEPRECATED for new projects)
-│       ├── Legacy GCP-native IaC
-│       ├── Jinja2 / Python templates
-│       └── Migrate to Terraform or KCC
-│       ⚠️  Only valid answer if question says "existing Deployment Manager"
+│   └── ⚠️  Deployment Manager (PAST END OF SUPPORT)
+│       ├── End of support 2026-04-01; new users blocked from 2026-06-30;
+│       │   full shutdown 2027-06-30
+│       ├── Jinja2 / Python templates over YAML
+│       └── Convert with DM Convert, then run the output through Infrastructure
+│           Manager or your own Terraform pipeline
+│       ⚠️  Only ever appears as "we have existing Deployment Manager templates",
+│           and then the answer is migrate -- never "keep using it"
 │
 ├── Multi-cloud, prefer general-purpose language (Python, Go, TS)?
 │   │
@@ -960,21 +1051,182 @@ How to manage GCP infrastructure as code?
 | Scenario | Tool | Architect Rationale |
 |----------|------|---------------------|
 | "Multi-cloud IaC, industry standard" | Terraform | Broadest provider support, largest community |
+| "Terraform, but no state bucket or CI runner to own" | Infrastructure Manager | Google-managed state and Cloud Build execution |
 | "GCP landing zone, best practices" | Terraform + CFT | Google-maintained modules for org setup |
 | "Team uses K8s for everything, wants one API" | Config Connector (KCC) | GCP resources as K8s CRDs, kubectl workflow |
 | "GitOps for GKE fleet config" | Config Sync | Git-driven cluster configuration |
 | "Enforce policies across Terraform" | OPA / Sentinel | Policy-as-code, pre-apply validation |
-| "Existing Deployment Manager templates" | Migrate to Terraform | DM is deprecated, use DM Converter tool |
+| "Existing Deployment Manager templates" | DM Convert → Terraform → Infrastructure Manager | DM is past end of support (2026-04-01) |
 | "IaC in Python, no HCL" | Pulumi | General-purpose languages for IaC |
 | "Remote Terraform state, team collaboration" | GCS backend + state locking | Prevent concurrent state corruption |
 | "Drift detection on GCP resources" | Config Connector (reconciliation) | Controller continuously enforces desired state |
 
 **Exam Tips:**
 - Terraform is almost always the correct IaC answer on the PCA exam unless the question specifically mentions Kubernetes-native management (Config Connector) or existing Deployment Manager.
-- Deployment Manager is deprecated for new projects. If the exam mentions it, the answer is usually "migrate to Terraform."
+- [Infrastructure Manager](https://cloud.google.com/infrastructure-manager/docs/overview) is Google's managed Terraform: same HCL, but Google owns the state, the revisions and the Cloud Build execution. Reach for it when the scenario says "we want IaC without operating the tooling" or "we need a Google-supported replacement for Deployment Manager." The v6.1 exam guide made IaC explicit, so this is worth knowing by name.
+- [Deployment Manager](https://cloud.google.com/deployment-manager/docs/deprecations) is past end of support (2026-04-01, shutdown 2027-06-30). If the exam mentions it, the answer is migrate: DM Convert produces Terraform, which you then run in Infrastructure Manager or your own pipeline.
 - Cloud Foundation Toolkit (CFT) is the architect-level Terraform answer for "set up a GCP organization following best practices."
 - Config Sync + Policy Controller is the answer for "enforce consistent policies across a fleet of GKE clusters."
 - State management: Terraform state in GCS with locking. Never store state locally in production.
+
+---
+
+## 11. Resource Hierarchy and Landing Zone
+
+```
+How should the organization be laid out?
+│
+├── What shape should the folder tree take?
+│   │   (Google's landing zone guidance gives three starting points, and says
+│   │    most organizations end up with a hybrid. It also says NOT to mirror
+│   │    the corporate org chart -- model policy needs, not reporting lines.)
+│   │
+│   ├── Dev / test / prod need different policy and different admins?
+│   │   └── ✅ Hierarchy based on application environments
+│   │       └── Folders: dev, nonprod, prod. Environment-specific org policies
+│   │           and IAM attach at the folder, not per project
+│   │
+│   ├── Regions or subsidiaries operate independently, with their own
+│   │   compliance and their own platform teams?
+│   │   └── ✅ Hierarchy based on regions or subsidiaries
+│   │       └── Use when data residency or local regulation differs, so the
+│   │           policy boundary genuinely follows geography
+│   │
+│   └── Clear per-product ownership, independent workloads, few shared policies?
+│       └── ✅ Hierarchy based on an accountability framework
+│           └── Each product team owns its subtree end to end
+│
+├── Where does a given control belong?
+│   │
+│   ├── Must apply everywhere and must not be opted out of?
+│   │   └── ✅ Organization policy at the org node
+│   │       └── e.g. disable service account key creation, restrict external IPs,
+│   │           require Shielded VM. Constraints inherit downward
+│   │
+│   ├── Applies to a class of projects (all prod, all of one subsidiary)?
+│   │   └── ✅ Org policy and IAM at the FOLDER
+│   │       └── This is the whole reason folders exist. Granting at the folder
+│   │           beats granting the same role on twenty projects
+│   │
+│   └── Applies to one workload?
+│       └── ✅ IAM at the project, or on the individual resource
+│           ⚠️  IAM allow policies are additive down the tree: you cannot
+│               subtract a grant made higher up by granting less lower down.
+│               To take something away you need an IAM deny policy, which is
+│               evaluated before allow policies
+│
+├── How finely should projects be split?
+│   │
+│   └── ✅ One project per application per environment is the usual default
+│       ├── Project is the billing boundary, the quota boundary and the
+│       │   default blast radius for IAM
+│       ├── Project ID is globally unique and cannot be changed after creation
+│       └── Shared services (logging, monitoring, networking, CI) get their own
+│           projects rather than living inside an application project
+│
+└── What must exist before the first workload lands?
+    ├── Identity: Cloud Identity or Workspace, groups as the IAM principals
+    │   (grant roles to groups, never to individual users)
+    ├── Hierarchy: folders and the org policies attached to them
+    ├── Networking: Shared VPC host projects, hybrid connectivity, DNS
+    ├── Logging: org-level aggregated sink to a dedicated logging project
+    ├── Billing: budgets and alerts on every project at creation time
+    └── Essential Contacts, so security and billing notices reach a human
+```
+
+### Hierarchy Quick Reference
+
+| Scenario | Answer | Architect Rationale |
+|----------|--------|---------------------|
+| "Same guardrail for every project, no exceptions" | Org policy at the organization node | Inherits down, cannot be granted away by project owners |
+| "Security team owns controls, app teams own workloads" | Policies at folder, IAM at project | Separation of duties follows the hierarchy |
+| "Revoke a permission someone inherited from a folder" | IAM deny policy | Allow policies are additive; only deny subtracts |
+| "Centralized network, many app teams" | Shared VPC host project + service projects | One network to administer, many projects to deploy into |
+| "Per-team cost visibility" | Project per app per env + labels + budgets | Project is the natural billing rollup |
+| "Stop spend when the budget is hit" | Budget alert plus a programmatic response | A budget alert on its own only notifies; it never stops spending |
+
+**Exam Tips:**
+- Folders can nest up to **10 levels** deep, and one parent can hold at most **300** direct child folders. Depth is almost never the real constraint; over-nesting is. ([Managing folders](https://cloud.google.com/resource-manager/docs/creating-managing-folders))
+- The classic trap: **budgets do not cap spending.** A budget with an alert threshold sends a notification. Actually stopping spend needs the Pub/Sub notification wired to something that disables billing or scales resources down.
+- IAM inheritance is a **union**. A role granted at the org is held on every project underneath it, and no project-level grant can reduce it. Only [IAM deny policies](https://cloud.google.com/iam/docs/deny-overview) subtract, and they evaluate first.
+- Grant roles to **groups**, not to users or to individual service accounts. Any question where access must survive people joining and leaving is testing this.
+- Google's landing zone guidance explicitly warns against mapping the corporate org chart onto the folder tree. If an option justifies a hierarchy with "it mirrors our reporting structure," that is the distractor. ([Decide resource hierarchy](https://cloud.google.com/architecture/landing-zones/decide-resource-hierarchy))
+
+---
+
+## 12. Network Topology Selection
+
+```
+How should these networks reach each other?
+│
+├── One network, many teams deploying into it, central network admins?
+│   └── ✅ Shared VPC
+│       ├── Host project owns the network and subnets
+│       ├── Service projects attach and place resources into those subnets
+│       ├── Network admins keep control; app teams never touch routing
+│       └── Single organization only
+│       ⚠️  This is the default answer for "centralized network, multiple teams"
+│
+├── Two networks need to route to each other, and there are only a few?
+│   └── ✅ VPC Network Peering
+│       ├── Both sides must create the peering; it is not one-sided
+│       ├── Subnet CIDRs must not overlap
+│       └── Works across projects and across organizations
+│       ⚠️  NON-TRANSITIVE. A peered to B and B peered to C does NOT give
+│           A to C. N networks needing any-to-any means N*(N-1)/2 peerings,
+│           which is the pain that pushes you to the next branch
+│
+├── Many VPCs, plus hybrid links, all needing any-to-any?
+│   └── ✅ Network Connectivity Center (hub and spoke)
+│       ├── VPC spokes exchange subnet routes with every other VPC spoke on
+│       │   the hub, giving full connectivity without pair-wise peerings
+│       ├── Hybrid spokes: HA VPN, Interconnect, router appliances
+│       └── One hub to operate instead of a peering mesh
+│       ⚠️  Mixing NCC and VPC Peering does not chain: a VPC reached through
+│           a peering is not reachable through the hub
+│
+├── Consuming a managed service privately, want no CIDR negotiation?
+│   └── ✅ Private Service Connect (PSC)
+│       ├── One internal IP in the consumer VPC represents the service
+│       ├── Traffic is NAT'd, so consumer and producer ranges can overlap
+│       ├── Producer explicitly authorizes which consumers may connect
+│       └── Works for Google APIs, Google-managed services and third-party SaaS
+│       ⚠️  Endpoints are consumer-to-producer. PSC interfaces are the separate
+│           mechanism for a producer initiating back toward the consumer
+│
+├── Managed service that requires an allocated range in your VPC?
+│   └── ✅ Private Service Access (service networking)
+│       ├── You reserve an IP range and Google peers the producer VPC to yours
+│       ├── The long-standing path for Cloud SQL, Memorystore, AlloyDB private IP
+│       └── Because it is peering underneath, it consumes address space and
+│           inherits peering's non-transitivity
+│       ⚠️  Where a service offers both, PSC is the more modern answer: no range
+│           to reserve and no peering side effects
+│
+└── Reaching Google APIs, not a VPC?
+    ├── From VMs with no external IP → ✅ Private Google Access (subnet setting)
+    ├── From on-premises over VPN/Interconnect → ✅ Private Google Access for
+    │   on-premises hosts (private.googleapis.com / restricted.googleapis.com)
+    └── Want an internal IP you control for a specific API → ✅ PSC endpoint
+```
+
+### Network Topology Quick Reference
+
+| Scenario | Answer | Architect Rationale |
+|----------|--------|---------------------|
+| "Central network team, many app projects" | Shared VPC | One network, delegated deployment |
+| "Two VPCs, mutual access, different orgs" | VPC Network Peering | Cross-org, no gateway, non-transitive |
+| "Twelve VPCs plus on-prem, all-to-all" | Network Connectivity Center | Hub replaces a 66-link peering mesh |
+| "Overlapping RFC 1918 after an acquisition" | Private Service Connect | NAT means no range renumbering |
+| "Cloud SQL on a private IP" | Private Service Access (or PSC where offered) | Producer peering with an allocated range |
+| "Expose our SaaS to customer VPCs privately" | PSC service attachment | Producer publishes, consumers get an endpoint |
+| "VMs with no public IP must call Cloud Storage" | Private Google Access | Subnet-level setting, no extra cost |
+
+**Exam Tips:**
+- **VPC Peering is non-transitive** and this is tested constantly. Any scenario with three or more networks and any-to-any requirements is pointing at [Network Connectivity Center](https://cloud.google.com/network-connectivity/docs/network-connectivity-center/concepts/vpc-spokes-overview), not at more peerings.
+- Overlapping IP ranges kill peering and Private Service Access, but not [Private Service Connect](https://cloud.google.com/vpc/docs/private-service-connect), because PSC NATs. "We acquired a company and the ranges collide" is a PSC question.
+- Shared VPC and VPC Peering solve different problems. Shared VPC is one network with delegated use; peering is two networks that stay separate and exchange routes. If the question stresses *who administers the network*, it is Shared VPC.
+- Private Google Access is a **subnet setting**, not a resource you create, and it costs nothing. If an option says you must deploy something to get it, that is wrong.
 
 ---
 
@@ -984,7 +1236,7 @@ Comprehensive mapping of common PCA exam scenarios to the recommended service or
 
 | # | Scenario | Recommended Service / Approach |
 |---|----------|-------------------------------|
-| 1 | "Global relational DB, 99.999% SLA, strong consistency" | Cloud Spanner (multi-region) |
+| 1 | "Global relational DB, 99.999% SLA, strong consistency" | Cloud Spanner, multi-region config, Enterprise Plus edition (regional Spanner is 99.99%) |
 | 2 | "PostgreSQL, need analytics on transactional data" | AlloyDB |
 | 3 | "Lift-and-shift MySQL to managed service" | Cloud SQL (via Database Migration Service) |
 | 4 | "Oracle RAC, cannot modify application" | Bare Metal Solution |
@@ -999,18 +1251,18 @@ Comprehensive mapping of common PCA exam scenarios to the recommended service or
 | 13 | "Stateless containers, scale to zero" | Cloud Run |
 | 14 | "Complex K8s, custom scheduling, node tuning" | GKE Standard |
 | 15 | "K8s without node management, enforced security" | GKE Autopilot |
-| 16 | "Spark/Hadoop migration from on-prem" | Dataproc |
+| 16 | "Spark/Hadoop migration from on-prem" | Managed Service for Apache Spark (formerly Dataproc) |
 | 17 | "Real-time stream processing, exactly-once" | Dataflow |
 | 18 | "Batch: 10,000 container jobs with retries" | Cloud Batch |
 | 19 | "SAP HANA, dedicated hardware" | Sole-tenant nodes (or Bare Metal Solution) |
 | 20 | "HPC, tightly coupled, MPI" | Compute Engine + compact placement policy |
-| 21 | "Highest bandwidth on-prem to GCP" | Dedicated Interconnect (10/100 Gbps) |
+| 21 | "Highest bandwidth on-prem to GCP" | Dedicated Interconnect (10 / 100 / 400 Gbps link types) |
 | 22 | "On-prem connectivity, no Google PoP nearby" | Partner Interconnect |
 | 23 | "Encrypted tunnel, quick setup" | HA VPN |
 | 24 | "Connect GCP to AWS with dedicated link" | Cross-Cloud Interconnect |
 | 25 | "Encrypt traffic over Interconnect" | HA VPN over Interconnect |
 | 26 | "Private access to Google APIs, no public IP" | Private Google Access / Private Service Connect |
-| 27 | "99.99% Interconnect SLA" | Dedicated Interconnect: 4 connections, 2 metros |
+| 27 | "99.99% Interconnect SLA" | Dedicated Interconnect: 4 connections, 2 per metro across 2 metros, split across edge availability domains |
 | 28 | "Global HTTPS, CDN, WAF" | Global External Application LB + Cloud Armor + Cloud CDN |
 | 29 | "Preserve client IP, UDP traffic" | External Passthrough Network LB |
 | 30 | "Internal microservices, gRPC routing" | Regional Internal Application LB |
@@ -1019,7 +1271,7 @@ Comprehensive mapping of common PCA exam scenarios to the recommended service or
 | 33 | "WAF, DDoS, OWASP Top 10" | Cloud Armor |
 | 34 | "Zero-trust app access, no VPN" | Identity-Aware Proxy (IAP) |
 | 35 | "Customer controls encryption keys" | Cloud KMS (CMEK) |
-| 36 | "Key must never leave customer's infrastructure" | Cloud EKM (External Key Manager) |
+| 36 | "Key must never leave customer's infrastructure" | Cloud EKM (External Key Manager) -- not CSEK, which is a raw key passed per request |
 | 37 | "Only deploy signed container images" | Binary Authorization |
 | 38 | "GitHub Actions → GKE, no service account keys" | Workload Identity Federation |
 | 39 | "GKE pod accesses Cloud Storage" | Workload Identity (K8s SA → GCP SA) |
@@ -1030,9 +1282,10 @@ Comprehensive mapping of common PCA exam scenarios to the recommended service or
 | 44 | "Zero downtime, global SaaS" | Active-Active: Spanner multi-region + GCLB + multi-region Cloud Run |
 | 45 | "DR for e-commerce, 1-hour RTO" | Warm DR: cross-region DB replica + scaled-down standby |
 | 46 | "Cheapest DR, 24-hour RPO acceptable" | Cold DR: GCS backups + Terraform |
-| 47 | "Move 200 VMs to GCP, no code changes" | Rehost: Migrate for Compute Engine (M4CE) |
+| 47 | "Move 200 VMs to GCP, no code changes" | Rehost: Migrate to Virtual Machines (formerly M4CE) |
 | 48 | "Monolith to microservices" | Refactor: GKE/Cloud Run + Pub/Sub + managed DBs |
 | 49 | "IaC, multi-cloud, industry standard" | Terraform |
+| 49b | "Terraform without owning state or CI runners" / "replace Deployment Manager" | Infrastructure Manager |
 | 50 | "GCP landing zone, org best practices" | Terraform + Cloud Foundation Toolkit (CFT) |
 | 51 | "GitOps for fleet of GKE clusters" | Config Sync + Policy Controller |
 | 52 | "Org-wide constraint: no external IPs" | Organization Policy (`vmExternalIpAccess`) |

--- a/gcp/pca/docs/10-key-commands-and-terraform.md
+++ b/gcp/pca/docs/10-key-commands-and-terraform.md
@@ -55,10 +55,17 @@ gcloud auth print-access-token --impersonate-service-account=SA@PROJECT.iam.gser
 
 # Workload Identity Federation - create pool
 gcloud iam workload-identity-pools create github-pool --location=global
+
+# The --attribute-condition is not optional in practice. GitHub, GitLab and HCP
+# Terraform each publish ONE issuer shared by every customer, so a provider with
+# no condition will accept a token from any repository on GitHub and let it
+# impersonate your service account. Scope it to your org, and to the repo if the
+# service account is repo-specific.
 gcloud iam workload-identity-pools providers create-oidc github \
   --workload-identity-pool=github-pool --location=global \
   --issuer-uri="https://token.actions.githubusercontent.com" \
-  --attribute-mapping="google.subject=assertion.sub"
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+  --attribute-condition="assertion.repository_owner=='my-org' && assertion.repository=='my-org/my-repo'"
 
 # IAM Recommender
 gcloud recommender recommendations list \
@@ -110,10 +117,18 @@ gcloud compute vpn-gateways create my-vpn-gw --network=my-vpc --region=us-centra
 gcloud compute routers create my-router --network=my-vpc --region=us-central1 --asn=65001
 
 # Create VPN tunnels (HA -- need two tunnels)
+# To an ON-PREMISES or third-party-cloud peer: --peer-external-gateway, which
+# refers to an external-vpn-gateway resource describing the far end's interfaces.
+gcloud compute external-vpn-gateways create onprem-gw \
+  --interfaces=0=203.0.113.10
 gcloud compute vpn-tunnels create tunnel-0 \
-  --vpn-gateway=my-vpn-gw --peer-gcp-gateway=peer-gw \
+  --vpn-gateway=my-vpn-gw --peer-external-gateway=onprem-gw \
+  --peer-external-gateway-interface=0 \
   --region=us-central1 --ike-version=2 --shared-secret=SECRET \
-  --router=my-router --vpn-gateway-interface=0
+  --router=my-router --interface=0
+
+# --peer-gcp-gateway is the OTHER case: HA VPN between two Google Cloud VPC
+# networks. Picking it for an on-premises peer is a common wrong answer.
 
 # Create hierarchical firewall policy
 gcloud compute firewall-policies create --organization=ORG_ID --short-name=org-fw
@@ -133,10 +148,20 @@ gcloud compute interconnects create my-interconnect \
   --location=FACILITY --requested-link-count=1
 
 # Load balancer (global external Application LB)
-gcloud compute backend-services create my-backend --global --protocol=HTTP
+# --load-balancing-scheme=EXTERNAL_MANAGED is what makes this the modern
+# Envoy-based global external ALB. Omitting it defaults to EXTERNAL, which builds
+# the Classic Application LB and silently gives up advanced traffic management.
+# The scheme must match on the backend service AND the forwarding rule.
+gcloud compute backend-services create my-backend \
+  --global --protocol=HTTP \
+  --load-balancing-scheme=EXTERNAL_MANAGED \
+  --health-checks=http-basic-check
 gcloud compute url-maps create my-url-map --default-service=my-backend
 gcloud compute target-https-proxies create my-proxy --url-map=my-url-map --ssl-certificates=my-cert
-gcloud compute forwarding-rules create my-lb --global --target-https-proxy=my-proxy --ports=443
+gcloud compute forwarding-rules create my-lb \
+  --global --target-https-proxy=my-proxy --ports=443 \
+  --load-balancing-scheme=EXTERNAL_MANAGED \
+  --network-tier=PREMIUM
 ```
 
 ### Cloud KMS
@@ -279,17 +304,19 @@ gcloud beta container backup-restore backup-plans create my-plan \
 ### Provider Configuration
 
 ```hcl
-# Required provider configuration
+# Required provider configuration.
+# Pin the major version only. The Google provider ships weekly, so a floating
+# constraint means an unreviewed provider upgrade lands in the middle of a plan.
 terraform {
   required_version = ">= 1.5"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.0"
+      version = "~> 7.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.0"
+      version = "~> 7.0"
     }
   }
 }
@@ -299,12 +326,25 @@ provider "google" {
   region  = var.region
 }
 
-# Beta provider for preview features
+# Only declare google-beta if you actually use a beta-only field. Most things
+# people reach for it out of habit (Autopilot, private clusters, Cloud Run v2)
+# have been GA in the main provider for years.
 provider "google-beta" {
   project = var.project_id
   region  = var.region
 }
 ```
+
+**Version and destroy-time gotcha.** The provider is on the 7.x line, so material
+pinned to `~> 5.0` is two majors behind. The upgrade that surprises people is
+`deletion_protection`: `google_container_cluster` and `google_sql_database_instance`
+both default it to `true`, and provider 6.0 extended the same pattern to
+`google_folder` and `google_project`. A `terraform destroy` on a tear-down
+environment fails until you set the field to `false` and apply that change first,
+which means two applies, not one. It also does nothing about deletion performed
+outside Terraform.
+
+**Docs:** [Google provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs), [6.0.0 upgrade guide](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_6_upgrade)
 
 ### State Management
 
@@ -441,14 +481,18 @@ module "gke" {
 ### Key Resource Examples
 
 ```hcl
-# GKE Autopilot cluster
+# GKE Autopilot cluster.
+# No provider = google-beta here: enable_autopilot has been GA in the main
+# provider for years. Older examples carry the beta pin for no reason.
 resource "google_container_cluster" "autopilot" {
-  provider = google-beta
-
   name     = "autopilot-cluster"
   location = "us-central1"
 
   enable_autopilot = true
+
+  # Defaults to true. Left explicit so the tear-down behaviour is visible at the
+  # call site rather than discovered when terraform destroy refuses to run.
+  deletion_protection = true
 
   release_channel {
     channel = "REGULAR"
@@ -502,9 +546,12 @@ resource "google_cloud_run_v2_service" "api" {
 # Cloud SQL with private IP and CMEK
 resource "google_sql_database_instance" "main" {
   name             = "prod-db"
-  database_version = "POSTGRES_15"
+  database_version = "POSTGRES_17"
   region           = "us-central1"
   encryption_key_name = google_kms_crypto_key.sql_key.id
+
+  # Defaults to true. Explicit here for the same reason as on the GKE cluster.
+  deletion_protection = true
 
   settings {
     tier              = "db-custom-4-16384"
@@ -583,13 +630,14 @@ steps:
 
 **Terraform vs alternatives:**
 
-| Feature | Terraform | Config Connector | Deployment Manager | Pulumi |
-|---------|-----------|-------------------|-------------------|--------|
-| Language | HCL | Kubernetes YAML | YAML/Jinja/Python | Python/TypeScript/Go |
-| State | Explicit (GCS) | Kubernetes API | Google-managed | Explicit |
-| Multi-cloud | Yes | No (GCP only) | No (GCP only) | Yes |
-| Ecosystem | Largest | Limited | Limited | Growing |
-| Status | Recommended | Active | Deprecated | Active |
+| Feature | Terraform | Infrastructure Manager | Config Connector | Deployment Manager | Pulumi |
+|---------|-----------|------------------------|-------------------|-------------------|--------|
+| Language | HCL | HCL (runs Terraform) | Kubernetes YAML | YAML/Jinja/Python | Python/TypeScript/Go |
+| State | You own it (GCS) | Google-managed, per revision | Kubernetes API | Google-managed | Explicit |
+| Execution | Your CI | Ephemeral Cloud Build jobs | In-cluster controller | Google-managed | Your CI |
+| Multi-cloud | Yes | No (GCP only) | No (GCP only) | No (GCP only) | Yes |
+| Ecosystem | Largest | Terraform's | Limited | Limited | Growing |
+| Status | Recommended | Active, DM's named successor | Active | End of support 2026-04-01 | Active |
 
 **Exam tips for Terraform:**
 - "Infrastructure as Code for GCP" --> Terraform (default answer)
@@ -597,9 +645,10 @@ steps:
 - State locking prevents concurrent modifications
 - `terraform import` brings existing resources under Terraform management
 - CFT modules are the Google-recommended starting point
-- Deployment Manager is DEPRECATED -- Terraform is the replacement
+- Deployment Manager is past end of support (2026-04-01, shutdown 2027-06-30). The named successor is [Infrastructure Manager](https://cloud.google.com/infrastructure-manager/docs/overview): convert with DM Convert, then run the resulting Terraform there.
+- "Managed Terraform on Google Cloud" is Infrastructure Manager, not Terraform Cloud. Both are valid, but only one is a Google product.
 
-**Docs:** [Terraform on Google Cloud](https://cloud.google.com/docs/terraform), [CFT](https://cloud.google.com/foundation-toolkit), [Config Connector](https://cloud.google.com/config-connector/docs)
+**Docs:** [Terraform on Google Cloud](https://cloud.google.com/docs/terraform), [Infrastructure Manager](https://cloud.google.com/infrastructure-manager/docs/overview), [CFT](https://cloud.google.com/foundation-toolkit), [Config Connector](https://cloud.google.com/config-connector/docs)
 
 ---
 
@@ -762,7 +811,7 @@ kubectl rollout resume deployment/my-app  # Continue rollout
 
 **Exam tips for kubectl:**
 - RBAC: ClusterRole/ClusterRoleBinding for cluster-wide, Role/RoleBinding for namespace-scoped
-- Network Policies require a CNI that supports them (Calico on GKE -- enabled by default on Standard)
+- NetworkPolicy needs a network plugin that enforces it, and on GKE that is now **Dataplane V2** (based on Cilium), which is the recommended plugin for all clusters and the default on Autopilot. Calico is the older plugin and is Standard-only. On a Standard cluster with Dataplane V2 you write NetworkPolicy objects directly; on a Standard cluster without it you must first turn network policy enforcement on. Either way it is **not on by default on Standard**, so a manifest applied to a fresh Standard cluster can silently do nothing. ([Network policies](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy), [Dataplane V2](https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2))
 - ResourceQuota is per namespace -- use for multi-tenant clusters
 - `kubectl rollout undo` rolls back to previous revision
 
@@ -803,21 +852,55 @@ export PUBSUB_EMULATOR_HOST=localhost:8085
 
 ---
 
-## 5. gsutil and bq at Architect Level
+## 5. Cloud Storage and BigQuery CLIs at Architect Level
 
-### gsutil Advanced
+### gcloud storage (the current CLI)
+
+`gcloud storage` is the supported Cloud Storage CLI and is generally faster than
+`gsutil` on large transfers. `gsutil` leaves the gcloud bundle in March 2027, so
+treat `gcloud storage` as the default and `gsutil` as the legacy form you still
+need to recognise, because the exam guide and older material name it.
+
+```bash
+# Copy, with parallelism handled automatically
+gcloud storage cp large-file.tar.gz gs://bucket/
+gcloud storage rsync ./local-dir gs://bucket/prefix --recursive
+
+# Generate a signed URL WITHOUT downloading a service account key.
+# Impersonation uses the IAM Credentials API to sign, so nothing is written to
+# disk. This is the form to use: gsutil signurl takes a key FILE, which
+# contradicts the "no service account keys, ever" rule elsewhere in this repo.
+# The caller needs roles/iam.serviceAccountTokenCreator on the signing SA.
+gcloud storage sign-url gs://bucket/object \
+  --duration=1h \
+  --impersonate-service-account=signer@project.iam.gserviceaccount.com
+
+# Set lifecycle policy
+gcloud storage buckets update gs://bucket/ --lifecycle-file=lifecycle.json
+
+# Run any command as another identity
+gcloud storage cp gs://src-bucket/file gs://dst-bucket/ \
+  --impersonate-service-account=sa@project.iam.gserviceaccount.com
+
+# Pub/Sub notifications on a bucket
+gcloud storage buckets notifications create gs://my-bucket --topic=my-topic
+```
+
+### gsutil (legacy, still recognised)
 
 ```bash
 # Parallel composite upload (for large files)
 gsutil -o GSUtil:parallel_composite_upload_threshold=150M cp large-file.tar.gz gs://bucket/
 
-# Generate signed URL (temporary access)
+# Signed URL. Note the positional key.json: gsutil signurl needs a downloaded
+# service account key unless you have one of the newer impersonation options.
+# Prefer gcloud storage sign-url --impersonate-service-account instead.
 gsutil signurl -d 1h key.json gs://bucket/object
 
 # Set lifecycle policy
 gsutil lifecycle set lifecycle.json gs://bucket/
 
-# Cross-project copy with service account
+# Cross-project copy with service account impersonation
 gsutil -i sa@project.iam.gserviceaccount.com cp gs://src-bucket/file gs://dst-bucket/
 
 # Configure notifications (to Pub/Sub)
@@ -851,9 +934,10 @@ bq query --dry_run --use_legacy_sql=false 'SELECT * FROM `project.dataset.table`
 ```
 
 **Exam tips:**
-- `gsutil signurl` generates pre-signed URLs for temporary access without IAM
+- Signed URLs give time-limited access to an object without the caller having any IAM grant or Google account. Generate them with `gcloud storage sign-url --impersonate-service-account`, which signs through the IAM Credentials API. The `gsutil signurl` form takes a key file on disk, which is exactly the pattern the rest of this material tells you to avoid, so prefer impersonation whenever both appear as options.
+- `gcloud storage` is the current CLI; `gsutil` exits the gcloud bundle in March 2027. Exam wording still uses `gsutil`, so recognise both and prefer `gcloud storage` in anything you would actually build.
 - `bq --dry_run` estimates query cost without running it
 - BigQuery slot reservations provide predictable pricing for heavy analytics
 - INFORMATION_SCHEMA queries are free (metadata only)
 
-**Docs:** [gsutil](https://cloud.google.com/storage/docs/gsutil), [bq CLI](https://cloud.google.com/bigquery/docs/reference/bq-cli-reference)
+**Docs:** [gcloud storage](https://cloud.google.com/sdk/gcloud/reference/storage), [Signed URLs](https://cloud.google.com/storage/docs/access-control/signed-urls), [gsutil](https://cloud.google.com/storage/docs/gsutil), [bq CLI](https://cloud.google.com/bigquery/docs/reference/bq-cli-reference)


### PR DESCRIPTION
## Summary

Errata for `docs/09-decision-trees.md` and `docs/10-key-commands-and-terraform.md`. Part of a five-lane sweep clearing the backlog in `.claude/state/research/2026-08-09-pca-content-audit.md`.

`docs/09` matters more than its size suggests: it is the file you review the night before, and it contained several errors that would directly produce a wrong answer.

## The worst one

The compute tree told you to pick **GKE Standard because "Autopilot has no DaemonSets"**, and separately because of GPUs. Both are false, and it was stated twice. Autopilot supports DaemonSets, GPUs and TPUs.

The branch now names the real discriminator -- node-level access: SSH to nodes, privileged containers outside the partner allowlist, host namespaces, unsafe sysctls, and changes to the node image -- with an explicit warning that "we need DaemonSets" is not a reason to pick Standard.

## Other tree errors that would cost a mark

| Was | Now |
|---|---|
| Spanner "~$650/mo minimum" | Minimum is 100 processing units, not one node. Off by 10x, and "Spanner is too expensive" is a distractor the exam uses |
| Spanner 99.999% as the entry condition | Five nines is multi-region only; regional is 99.99% |
| Firestore "cannot change mode after creation" (stated twice) | An empty database can switch, and both modes coexist in one project |
| Firestore "under 10 TB" branch threshold | Invented. No such documented limit |
| "Bigtable: no SQL" | GoogleSQL for Bigtable is GA |
| CSEK and EKM conflated | Split, matching the file's own correct tip further down |
| Network tags preferred for firewall targeting | Google recommends service accounts; secure tags now close the gap |
| Cloud SQL cross-region DR needs manual promotion | Enterprise Plus has advanced DR with replica failover and zero-data-loss switchover |

Plus: Memcached deprecation with Valkey added, Dataproc to Managed Service for Apache Spark, M4CE to Migrate to Virtual Machines, Deployment Manager EOL with Infrastructure Manager added to the IaC tree, Interconnect 400 Gbps and edge availability domains, HA VPN as 250,000 pps rather than a flat 3 Gbps, and turbo replication's real 15-minute guarantee.

## Two new decision trees

**Resource hierarchy / landing zone** and **network topology selection** (Shared VPC vs Peering vs Network Connectivity Center vs PSC vs Private Service Access). Both were named gaps, and the second covers the most commonly tested networking decision at architect level.

## docs/10 fixes

- The **Workload Identity Federation** example had no `--attribute-condition`. For the GitHub Actions issuer that is the well-known misconfiguration letting *any* GitHub repository mint tokens for your service account. Now repository-scoped.
- The "global external ALB" snippet actually built a **Classic** ALB. Now sets `--load-balancing-scheme=EXTERNAL_MANAGED` on both resources.
- The HA VPN example used `--peer-gcp-gateway` (VPC-to-VPC) while the text described the on-premises case, which needs `--peer-external-gateway`.
- **Bonus find:** checking flags against local `gcloud --help` caught `--vpn-gateway-interface`, which does not exist. The correct flag is `--interface`. This was not in the errata.
- `gsutil signurl` required a downloaded service account key, contradicting the repo's own "no service account keys, ever" guidance. Replaced with `gcloud storage sign-url --impersonate-service-account`.
- Network policy corrected to Dataplane V2, and to "not enabled by default on Standard".
- Provider pin moved to `~> 7.0`, with the v6+ `deletion_protection` destroy-time surprise documented.

## A correction to the errata itself

The errata said the AlloyDB claim should become "4x standard PostgreSQL". That figure could not be verified on any reachable `cloud.google.com` page either, so the multiplier was **removed** rather than swapped for another unverifiable number, and only the direction of the comparison is stated.

Also left alone: Bigtable per-node price and the Partner Interconnect bandwidth range, both unverifiable. And `docs/09:330` repeats the "Classic VPN is deprecated" falsehood, but the errata scopes that item to `docs/02`, so it is flagged rather than silently fixed.

## Verification

Zero em dashes added, zero TODO markers. ASCII tree style preserved throughout.